### PR TITLE
Add implicit realm error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.0-preview2 - TBD
 
 + Improve GSSAPI and Kebreros library loading
++ Added error messages to describe why PSOpenAD failed to find the implicit DC host
 + Change `-UseSSL` to `-UseTLS`
 
 ## v0.1.0-preview1 - 2022-02-1

--- a/src/Native/Kerberos.cs
+++ b/src/Native/Kerberos.cs
@@ -48,7 +48,7 @@ internal static class Kerberos
     /// </remarks>
     /// <param name="context">The Kerberos context handle.</param>
     /// <returns>The the default realm.</returns>
-    /// <exception cref="KerberosException">Kerberos error reported, most likely no realm was found..</exception>
+    /// <exception cref="KerberosException">Kerberos error reported, most likely no realm was found.</exception>
     /// <see href="https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_get_default_realm.html">krb5_get_default_realm</see>
     public static string GetDefaultRealm(SafeKrb5Context context)
     {

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -111,8 +111,13 @@ internal sealed class OpenADSessionFactory
         {
             if (GlobalState.DefaultDC == null)
             {
+                string msg = "Cannot determine default realm for implicit domain controller.";
+                if (!string.IsNullOrEmpty(GlobalState.DefaultDCError))
+                {
+                    msg += $" {GlobalState.DefaultDCError}";
+                }
                 cmdlet.WriteError(new ErrorRecord(
-                    new ArgumentException("Cannot determine default realm for implicit domain controller."),
+                    new ArgumentException(msg),
                     "NoImplicitDomainController",
                     ErrorCategory.InvalidArgument,
                     null));
@@ -623,4 +628,7 @@ internal static class GlobalState
 
     /// <summary>The default domain controller hostname to use when none was provided.</summary>
     public static Uri? DefaultDC;
+
+    /// <summary>If the default DC couldn't be detected this stores the details.</summary>
+    public static string? DefaultDCError;
 }


### PR DESCRIPTION
Provide a better description of why PSOpenAD failed to find the default
domain controller of the client. This is typically due to library
failures or DNS/client configuration issues.

Fixes https://github.com/jborean93/PSOpenAD/issues/8