### PR TITLE
Automatically append $ to computer/service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 + Improve GSSAPI and Kebreros library loading
 + Added error messages to describe why PSOpenAD failed to find the implicit DC host
 + Change `-UseSSL` to `-UseTLS`
++ Always add `$` to the `-Identity` of `Get-OpenADComputer` and `Get-OpenADServiceAccount` when using a `sAMAccountName`
 
 ## v0.1.0-preview1 - 2022-02-1
 

--- a/src/ADIdentity.cs
+++ b/src/ADIdentity.cs
@@ -46,6 +46,8 @@ public class ADObjectIdentity
 
 public class ADPrincipalIdentity : ADObjectIdentity
 {
+    public virtual bool SamEndsWithDollar => false;
+
     public ADPrincipalIdentity(string value)
     {
         if (TryParseGuid(value, out var filter))
@@ -89,6 +91,10 @@ public class ADPrincipalIdentity : ADObjectIdentity
         if (m.Success)
         {
             string username = m.Groups["username"].Value;
+            if (SamEndsWithDollar && !username.EndsWith('$'))
+            {
+                username += "$";
+            }
             filter = new FilterEquality("sAMAccountName", LDAPFilter.EncodeSimpleFilterValue(username));
             return true;
         }
@@ -119,4 +125,17 @@ public class ADPrincipalIdentity : ADObjectIdentity
         sid.GetBinaryForm(sidBytes, 0);
         return new FilterEquality("objectSid", sidBytes);
     }
+}
+
+public class ADPrincipalIdentityWithDollar : ADPrincipalIdentity
+{
+    public override bool SamEndsWithDollar => true;
+
+    public ADPrincipalIdentityWithDollar(string value) : base(value) { }
+
+    public ADPrincipalIdentityWithDollar(SecurityIdentifier sid) : base(sid) { }
+
+    public ADPrincipalIdentityWithDollar(OpenADObject obj) : base(obj) { }
+
+    public ADPrincipalIdentityWithDollar(Guid objectGuid) : base(objectGuid) { }
 }

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -276,7 +276,7 @@ public class GetOpenADComputer : GetOpenADOperation
         ValueFromPipelineByPropertyName = true,
         ParameterSetName = "SessionIdentity"
     )]
-    public ADPrincipalIdentity Identity { get => null!; set => _ldapFilter = value.LDAPFilter; }
+    public ADPrincipalIdentityWithDollar Identity { get => null!; set => _ldapFilter = value.LDAPFilter; }
 
     internal override (string, bool)[] DefaultProperties => OpenADComputer.DEFAULT_PROPERTIES;
 
@@ -366,7 +366,7 @@ public class GetOpenADServiceAccount : GetOpenADOperation
         ValueFromPipelineByPropertyName = true,
         ParameterSetName = "SessionIdentity"
     )]
-    public ADPrincipalIdentity Identity { get => null!; set => _ldapFilter = value.LDAPFilter; }
+    public ADPrincipalIdentityWithDollar Identity { get => null!; set => _ldapFilter = value.LDAPFilter; }
 
     internal override (string, bool)[] DefaultProperties => OpenADServiceAccount.DEFAULT_PROPERTIES;
 

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -1,0 +1,28 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Describe "Get-OpenADComputer" -Skip:(-not $PSOpenADSettings.Server) {
+    BeforeAll {
+        $selectedCred = $PSOpenADSettings.Credentials | Select-Object -First 1
+        $cred = [pscredential]::new($selectedCred.Username, $selectedCred.Password)
+
+        $session = New-OpenADSession -ComputerName $PSOpenADSettings.Server -Credential $cred
+    }
+
+    AfterAll {
+        $session | Remove-OpenADSession
+    }
+
+    It "Finds ADComputer by -Identity sAMAccountName without ending $" {
+        $dcName = @($PSOpenADSettings.Server -split '\.')[0]
+        $actual = Get-OpenADComputer -Session $session -Identity $dcName
+        $actual.Name | Should -Be $dcName
+        $actual.SamAccountName | Should -Be "$dcName$"
+    }
+
+    It "Finds ADComputer by -Identity sAMAccountName" {
+        $dcName = @($PSOpenADSettings.Server -split '\.')[0]
+        $actual = Get-OpenADComputer -Session $session -Identity $dcName$
+        $actual.Name | Should -Be $dcName
+        $actual.SamAccountName | Should -Be "$dcName$"
+    }
+}


### PR DESCRIPTION
Always append $ to the -Identity of a Computer or Service Account
sAMAccountName value.

Fixes https://github.com/jborean93/PSOpenAD/issues/6