### PR TITLE
Fix pipelined -Identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 + Added error messages to describe why PSOpenAD failed to find the implicit DC host
 + Change `-UseSSL` to `-UseTLS`
 + Always add `$` to the `-Identity` of `Get-OpenADComputer` and `Get-OpenADServiceAccount` when using a `sAMAccountName`
++ Fix piping of multiple `-Identity` values into the `Get-OpenAD*` cmdlets
 
 ## v0.1.0-preview1 - 2022-02-1
 

--- a/docs/en-US/Get-OpenADComputer.md
+++ b/docs/en-US/Get-OpenADComputer.md
@@ -14,15 +14,15 @@ Get one or more Active Directory computers.
 
 ### ServerIdentity (Default)
 ```
-Get-OpenADComputer [[-Identity] <ADPrincipalIdentity>] [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-Property <String[]>]
- [<CommonParameters>]
+Get-OpenADComputer [-Server <String>] [-AuthType <AuthenticationMethod>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
+ [[-Identity] <ADPrincipalIdentityWithDollar>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADComputer [[-Identity] <ADPrincipalIdentity>] -Session <OpenADSession> [-Property <String[]>]
- [<CommonParameters>]
+Get-OpenADComputer -Session <OpenADSession> [[-Identity] <ADPrincipalIdentityWithDollar>]
+ [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
@@ -153,7 +153,7 @@ In addition the identity is filtered by the LDAP filter `(objectCategory=compute
 The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
-Type: ADPrincipalIdentity
+Type: ADPrincipalIdentityWithDollar
 Parameter Sets: ServerIdentity, SessionIdentity
 Aliases:
 

--- a/docs/en-US/Get-OpenADGroup.md
+++ b/docs/en-US/Get-OpenADGroup.md
@@ -14,14 +14,14 @@ Gets one or more Active Directory groups.
 
 ### ServerIdentity (Default)
 ```
-Get-OpenADGroup [[-Identity] <ADPrincipalIdentity>] [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-Property <String[]>]
+Get-OpenADGroup [-Server <String>] [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>]
+ [-StartTLS] [-Credential <PSCredential>] [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
  [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADGroup [[-Identity] <ADPrincipalIdentity>] -Session <OpenADSession> [-Property <String[]>]
+Get-OpenADGroup -Session <OpenADSession> [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
  [<CommonParameters>]
 ```
 

--- a/docs/en-US/Get-OpenADObject.md
+++ b/docs/en-US/Get-OpenADObject.md
@@ -14,14 +14,14 @@ Gets one or more Active Directory objects.
 
 ### ServerIdentity (Default)
 ```
-Get-OpenADObject [-Identity <ADObjectIdentity>] [-IncludeDeletedObjects] [-Server <String>]
- [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>] [-StartTLS]
- [-Credential <PSCredential>] [-Property <String[]>] [<CommonParameters>]
+Get-OpenADObject [-IncludeDeletedObjects] [-Server <String>] [-AuthType <AuthenticationMethod>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
+ [-Identity <ADObjectIdentity>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADObject [-Identity <ADObjectIdentity>] [-IncludeDeletedObjects] -Session <OpenADSession>
+Get-OpenADObject [-IncludeDeletedObjects] -Session <OpenADSession> [-Identity <ADObjectIdentity>]
  [-Property <String[]>] [<CommonParameters>]
 ```
 

--- a/docs/en-US/Get-OpenADServiceAccount.md
+++ b/docs/en-US/Get-OpenADServiceAccount.md
@@ -14,15 +14,15 @@ Gets one or more Active Directory managed service accounts or group managed serv
 
 ### ServerIdentity (Default)
 ```
-Get-OpenADServiceAccount [[-Identity] <ADPrincipalIdentity>] [-Server <String>]
- [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>] [-StartTLS]
- [-Credential <PSCredential>] [-Property <String[]>] [<CommonParameters>]
+Get-OpenADServiceAccount [-Server <String>] [-AuthType <AuthenticationMethod>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
+ [[-Identity] <ADPrincipalIdentityWithDollar>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADServiceAccount [[-Identity] <ADPrincipalIdentity>] -Session <OpenADSession> [-Property <String[]>]
- [<CommonParameters>]
+Get-OpenADServiceAccount -Session <OpenADSession> [[-Identity] <ADPrincipalIdentityWithDollar>]
+ [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
@@ -153,7 +153,7 @@ In addition the identity is filtered by the LDAP filter `(objectCategory=msDS-Gr
 The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
-Type: ADPrincipalIdentity
+Type: ADPrincipalIdentityWithDollar
 Parameter Sets: ServerIdentity, SessionIdentity
 Aliases:
 

--- a/docs/en-US/Get-OpenADUser.md
+++ b/docs/en-US/Get-OpenADUser.md
@@ -14,14 +14,14 @@ Gets one or more Active Directory users.
 
 ### ServerIdentity (Default)
 ```
-Get-OpenADUser [[-Identity] <ADPrincipalIdentity>] [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-Property <String[]>]
+Get-OpenADUser [-Server <String>] [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>]
+ [-StartTLS] [-Credential <PSCredential>] [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
  [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADUser [[-Identity] <ADPrincipalIdentity>] -Session <OpenADSession> [-Property <String[]>]
+Get-OpenADUser -Session <OpenADSession> [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
  [<CommonParameters>]
 ```
 

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -1,28 +1,46 @@
 . ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
 
-Describe "Get-OpenADComputer" -Skip:(-not $PSOpenADSettings.Server) {
+Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
     BeforeAll {
         $selectedCred = $PSOpenADSettings.Credentials | Select-Object -First 1
         $cred = [pscredential]::new($selectedCred.Username, $selectedCred.Password)
 
         $session = New-OpenADSession -ComputerName $PSOpenADSettings.Server -Credential $cred
+        $dcName = @($PSOpenADSettings.Server -split '\.')[0]
     }
 
     AfterAll {
         $session | Remove-OpenADSession
     }
 
-    It "Finds ADComputer by -Identity sAMAccountName without ending $" {
-        $dcName = @($PSOpenADSettings.Server -split '\.')[0]
-        $actual = Get-OpenADComputer -Session $session -Identity $dcName
-        $actual.Name | Should -Be $dcName
-        $actual.SamAccountName | Should -Be "$dcName$"
+    Context "Get-OpenADComputer" {
+        It "Finds ADComputer by -Identity sAMAccountName without ending $" {
+            $actual = Get-OpenADComputer -Session $session -Identity $dcName
+            $actual.Name | Should -Be $dcName
+            $actual.SamAccountName | Should -Be "$dcName$"
+        }
+
+        It "Finds ADComputer by -Identity sAMAccountName" {
+            $actual = Get-OpenADComputer -Session $session -Identity $dcName$
+            $actual.Name | Should -Be $dcName
+            $actual.SamAccountName | Should -Be "$dcName$"
+        }
+
+        It "Finds ADComputer through pipeline input" {
+            $actual = $dcName, "$dcName$" | Get-OpenADComputer -Session $session
+            $actual.Count | Should -Be 2
+            $actual[0] | Should -BeOfType ([PSOpenAD.OpenADComputer])
+            $actual[1] | Should -BeOfType ([PSOpenAD.OpenADComputer])
+            $actual[0].ObjectGuid | Should -Be $actual[1].ObjectGuid
+        }
     }
 
-    It "Finds ADComputer by -Identity sAMAccountName" {
-        $dcName = @($PSOpenADSettings.Server -split '\.')[0]
-        $actual = Get-OpenADComputer -Session $session -Identity $dcName$
-        $actual.Name | Should -Be $dcName
-        $actual.SamAccountName | Should -Be "$dcName$"
+    Context "Get-OpenADGroup" {
+        It "Finds ADGroup through pipeline input" {
+            $actual = "Domain Admins", "Domain Users" | Get-OpenADGroup -Session $session
+            $actual.Count | Should -Be 2
+            $actual[0] | Should -BeOfType ([PSOpenAD.OpenADGroup])
+            $actual[1] | Should -BeOfType ([PSOpenAD.OpenADGroup])
+        }
     }
 }


### PR DESCRIPTION
Fixes multiple identities being passed into the pipeline of the
Get-OpenAD* cmdlets.

Fixes https://github.com/jborean93/PSOpenAD/issues/7