### PR TITLE
Accept hostname:port for -Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSOpenAD
 
+## v0.1.0-preview3 - TBD
+
++ Allow using `hostname:port` syntax when using `-Server` rather than always requiring the full LDAP URI
+
 ## v0.1.0-preview2 - 2022-02-22
 
 + Improve GSSAPI and Kebreros library loading

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -95,7 +95,7 @@
 
         PSData = @{
 
-            Prerelease   = 'preview2'
+            Prerelease   = 'preview3'
 
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags         = @(

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -131,6 +131,25 @@ internal sealed class OpenADSessionFactory
         {
             ldapUri = new Uri(server);
         }
+        else if (server.Contains(":"))
+        {
+            string[] serverSplit = server.Split(':', 2);
+            if (int.TryParse(serverSplit[1], out var port))
+            {
+                string scheme = port == 636 || port == 3269 ? "ldaps" : "ldap";
+                ldapUri = new Uri($"{scheme}://{server}/");
+            }
+            else
+            {
+                string msg = "Expecting server in the format of hostname or hostname:port with port as an integer";
+                cmdlet.WriteError(new ErrorRecord(
+                    new ArgumentException(msg),
+                    "InvalidServerPort",
+                    ErrorCategory.InvalidArgument,
+                    null));
+                return null;
+            }
+        }
         else
         {
             ldapUri = new Uri($"ldap://{server}:389/");

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -10,7 +10,24 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
     }
 
     AfterAll {
-        $session | Remove-OpenADSession
+        Get-OpenADSession | Remove-OpenADSession
+    }
+
+    Context "Get-OpenADObject" {
+        It "Creates session using hostname" {
+            Get-OpenADObject -Server $PSOpenADSettings.Server | Out-Null
+        }
+
+        It "Creates sessoin using hostname:port" {
+            Get-OpenADObject -Server "$($PSOpenADSettings.Server):389" | Out-Null
+        }
+
+        It "Fails to create server with invalid hostname:port" {
+            $expected = "Expecting server in the format of hostname or hostname:port with port as an integer"
+            {
+                Get-OpenADObject -Server hostname:port -ErrorAction Stop
+            } | Should -Throw -ExceptionType ([ArgumentException]) -ExpectedMessage $expected
+        }
     }
 
     Context "Get-OpenADComputer" {


### PR DESCRIPTION
Allow the caller to set the -Server value in the form of hostname:port
instead of requiring the full LDAP URI. Using port 636 or 3269 will use
LDAPS otherwise LDAP is used for any other port.

Fixes https://github.com/jborean93/PSOpenAD/issues/12