### PR TITLE
Process referrals and add integration environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,5 @@ FodyWeavers.xsd
 output/
 tools/Modules
 test.settings.json
+tests/integration/.vagrant
+tests/integration/cert_setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.1.0-preview4 - TBD
 
++ Added error handling for search request that ends with a referral
+  + Currently the cmdlet will emit an error record with the referral URI which is similar to what the AD cmdlets do
+
 ## v0.1.0-preview3 - 2022-03-22
 
 + Allow using `hostname:port` syntax when using `-Server` rather than always requiring the full LDAP URI

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,12 @@
+# PSOpenAD Integration Environment
+
+This contains a Vagrantfile and Ansible playbook that can be used to setup an AD environment to test PSOpenAD with.
+The plan is to expand this environment setup to test out edge case scenarios that cannot be done through CI.
+
+To set up the environment run the following:
+
+```bash
+vagrant up
+
+ansible-playbook main.yml -vv
+```

--- a/tests/integration/Vagrantfile
+++ b/tests/integration/Vagrantfile
@@ -1,0 +1,35 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+inventory = YAML.load_file('inventory.yml')
+
+Vagrant.configure("2") do |config|
+  inventory['all']['children'].each do |group,group_details|
+    group_details['hosts'].each do |server,details|
+
+      config.vm.define server do |srv|
+        srv.vm.box = details['vagrant_box']
+        srv.vm.hostname = server
+        srv.vm.network :private_network,
+            :ip => details['ansible_host'],
+            :libvirt__domain_name => inventory['all']['vars']['domain_name'],
+            :libvirt__network_name => 'PSOpenAD'
+
+        srv.vm.provider :libvirt do |l|
+          l.memory = 4096
+          l.cpus = 2
+        end
+
+        if group == "linux"
+          srv.vm.provision "shell", inline: <<-SHELL
+            sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+            systemctl restart sshd.service
+          SHELL
+        end
+      end
+
+    end
+  end
+end

--- a/tests/integration/ansible.cfg
+++ b/tests/integration/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventory.yml
+retry_files_enabled = False
+stdout_callback = yaml

--- a/tests/integration/inventory.yml
+++ b/tests/integration/inventory.yml
@@ -1,0 +1,42 @@
+all:
+  children:
+    windows:
+      hosts:
+        DC01:
+          ansible_host: 192.168.2.10
+          vagrant_box: jborean93/WindowsServer2022
+        DC02:
+          ansible_host: 192.168.2.11
+          domain_name_prefix: foo.
+          vagrant_box: jborean93/WindowsServer2022
+        DC03:
+          ansible_host: 192.168.2.12
+          domain_name_prefix: bar.
+          vagrant_box: jborean93/WindowsServer2022
+        # APP01:
+        #   ansible_host: 192.168.2.13
+        #   vagrant_box: jborean93/WindowsServer2022
+      vars:
+        ansible_connection: winrm
+        ansible_winrm_transport: ntlm
+        ansible_port: 5985
+
+    # linux:
+    #   hosts:
+    #     DEBIAN11-MIT:
+    #       ansible_host: 192.168.2.14
+    #       vagrant_box: generic/debian11
+    #     DEBIAN11-HEIMDAL:
+    #       ansible_host: 192.168.2.14
+    #       vagrant_box: generic/debian11
+    #   vars:
+    #     ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+
+  vars:
+    ansible_user: vagrant
+    ansible_password: vagrant
+
+    domain_name: ldap.test
+    domain_username: ldap
+    domain_password: Password01
+    domain_user_upn: '{{ domain_username }}@{{ domain_name | upper }}'

--- a/tests/integration/library/win_domain_child.ps1
+++ b/tests/integration/library/win_domain_child.ps1
@@ -1,0 +1,101 @@
+#!powershell
+
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options             = @{
+        dns_domain_name       = @{ type = 'str' }
+        domain_admin_password = @{ type = 'str'; required = $true; no_log = $true }
+        domain_admin_username = @{ type = 'str'; required = $true }
+        site_name             = @{ type = 'str' }
+        safe_mode_password    = @{ type = 'str'; no_log = $true }
+    }
+    required_together   = @(
+        , @("domain_admin_username", "domain_admin_password")
+    )
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$dnsDomainName = $module.Params.dns_domain_name
+$domainAdminUserName = $module.Params.domain_admin_username
+$domainAdminPassword = $module.Params.domain_admin_password
+$safeModePassword = $module.Params.safe_mode_password
+$siteName = $module.Params.site_name
+
+$module.Result.reboot_required = $false
+
+$systemRole = Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain, DomainRole
+if ($systemRole.DomainRole -in @(4, 5)) {
+    if ($systemRole.Domain -ne $dnsDomainName) {
+        $module.FailJson("Host is already a domain controller in another domain $($systemRole.Domain)")
+    }
+    $module.ExitJson()
+}
+
+$newDomainName, $parentDomainName = $dnsDomainName.Split(".", 2)
+
+$cred = New-Object -TypeName PSCredential -ArgumentList @(
+    $domainAdminUserName,
+    (ConvertTo-SecureString -AsPlainText -Force -String $domainAdminPassword)
+)
+$installParams = @{
+    NewDomainName                 = $newDomainName
+    ParentDomainName              = $parentDomainName
+    DomainMode                    = 'WinThreshold'
+    DomainType                    = 'ChildDomain'
+    NoRebootOnCompletion          = $true
+    SafeModeAdministratorPassword = (ConvertTo-SecureString -AsPlainText -Force -String $safeModePassword)
+    Force                         = $true
+    Credential                    = $cred
+    WhatIf                        = $module.CheckMode
+}
+if ($siteName) {
+    $installParams.SiteName = $siteName
+}
+
+$res = $null
+try {
+    $res = Install-ADDSDomain @installParams
+}
+catch {
+    # ExitCode 15 == 'Role change is in progress or this computer needs to be restarted.'
+    # DCPromo exit codes details can be found at
+    # https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/troubleshooting-domain-controller-deployment
+    if ($_.Exception.ErrorCode -in @(15, 19)) {
+        $module.Result.reboot_required = $true
+    }
+    else {
+        $module.FailJson("Failed to install ADDSDomain, DCPromo exited with $($_.Exception.ExitCode)", $_)
+    }
+}
+
+$module.Result.changed = $true
+
+if ($module.CheckMode) {
+    $module.Result.reboot_required = $true
+}
+elseif ($res) {
+    $module.Result.reboot_required = $res.RebootRequired
+
+    # The Netlogon service is set to auto start but is not started. This is
+    # required for Ansible to connect back to the host and reboot in a
+    # later task. Even if this fails Ansible can still connect but only
+    # with ansible_winrm_transport=basic so we just display a warning if
+    # this fails.
+    try {
+        Start-Service -Name Netlogon
+    }
+    catch {
+        $msg = -join @(
+            "Failed to start the Netlogon service after promoting the host, "
+            "Ansible may be unable to connect until the host is manually rebooting: $($_.Exception.Message)"
+        )
+        $module.Warn($msg)
+    }
+}
+
+$module.ExitJson()

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -1,0 +1,187 @@
+- name: setup local configuration and scratch information
+  hosts: localhost
+  gather_facts: no
+
+  tasks:
+  - name: create cert output folder
+    file:
+      path: '{{ playbook_dir }}/cert_setup'
+      state: directory
+
+  - name: create generate_cert script
+    template:
+      src: generate_cert.sh.j2
+      dest: '{{ playbook_dir }}/cert_setup/generate_cert.sh'
+      mode: '700'
+
+  - name: generate CA and LDAPS certificates
+    shell: ./generate_cert.sh password
+    args:
+      creates: '{{ playbook_dir }}/cert_setup/complete.txt'
+      chdir: '{{ playbook_dir }}/cert_setup'
+
+- name: setup common Windows information
+  hosts: windows
+  gather_facts: no
+  tags:
+  - windows
+
+  tasks:
+  - name: get network connection names
+    win_shell: |
+      Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'" | ForEach-Object -Process {
+        $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index='$($_.Index)'"
+        if ($config.IPAddress -contains '{{ ansible_host }}') {
+          $_.NetConnectionID
+        }
+      }
+    changed_when: false
+    register: raw_connection_name
+
+  - set_fact:
+      public_connection_name: '{{ raw_connection_name.stdout | trim }}'
+
+  - name: copy CA certificate
+    win_copy:
+      src: '{{ playbook_dir }}/cert_setup/ca.pem'
+      dest: C:\Windows\TEMP\ca.pem
+
+  - name: import CA certificate to trusted root CA
+    win_certificate_store:
+      path: C:\Windows\TEMP\ca.pem
+      state: present
+      store_location: LocalMachine
+      store_name: Root
+
+- name: create root domain controller
+  hosts: DC01
+  gather_facts: no
+  tags:
+  - windows
+
+  tasks:
+  - name: set the DNS for the internal adapters to localhost
+    win_dns_client:
+      adapter_names:
+      - '{{ public_connection_name }}'
+      dns_servers:
+      - 127.0.0.1
+
+  - name: ensure domain exists and DC is promoted as a domain controller
+    win_domain:
+      dns_domain_name: '{{ domain_name }}'
+      safe_mode_password: '{{ domain_password }}'
+    register: domain_setup_res
+
+  - name: reboot after DC install
+    win_reboot:
+    when: domain_setup_res.reboot_required
+
+  - name: create domain username
+    win_domain_user:
+      name: '{{ domain_username }}'
+      upn: '{{ domain_user_upn }}'
+      description: '{{ domain_username }} Domain Account'
+      password: '{{ domain_password }}'
+      password_never_expires: yes
+      update_password: when_changed
+      groups:
+      - Domain Admins
+      - Enterprise Admins
+      state: present
+
+  - name: copy LDAPS certificate
+    win_copy:
+      src: '{{ playbook_dir }}/cert_setup/dc01.pfx'
+      dest: C:\Windows\TEMP\ldaps.pfx
+
+  - name: import LDAPS certificate
+    win_certificate_store:
+      path: C:\Windows\TEMP\ldaps.pfx
+      password: password
+      key_exportable: no
+      key_storage: machine
+      state: present
+      store_type: service
+      store_location: NTDS
+      store_name: My
+    register: ldaps_cert_info
+
+  - name: register LDAPS certificate
+    win_shell: |
+      $dse = [adsi]'LDAP://localhost/rootDSE'
+      [void]$dse.Properties['renewServerCertificate'].Add(1)
+      $dse.CommitChanges()
+    when: ldaps_cert_info is changed
+    vars:
+      ansible_become: yes
+      ansible_become_method: runas
+      ansible_become_user: '{{ domain_user_upn }}'
+      ansible_become_pass: '{{ domain_password }}'
+
+- name: create sub domains
+  hosts: DC02,DC03
+  gather_facts: no
+  tags:
+  - windows
+
+  tasks:
+  - name: set DNS for the private adapter to point to the root domain
+    win_dns_client:
+      adapter_names:
+      - '{{ public_connection_name }}'
+      dns_servers:
+      - '{{ hostvars["DC01"]["ansible_host"] }}'
+
+  - name: ensure domain creation feature is installed
+    win_feature:
+      name:
+      - AD-Domain-Services
+      - RSAT-ADDS
+      state: present
+    register: domain_feature_install
+
+  - name: reboot if required by feature install
+    win_reboot:
+    when: domain_feature_install.reboot_required
+
+  - name: create sub domain
+    win_domain_child:
+      dns_domain_name: '{{ domain_name_prefix }}{{ domain_name }}'
+      domain_admin_username: '{{ domain_user_upn }}'
+      domain_admin_password: '{{ domain_password }}'
+      safe_mode_password: '{{ domain_password }}'
+    register: domain_create
+
+  - name: reboot after creating sub domain
+    win_reboot:
+    when: domain_create.reboot_required
+
+  - name: copy LDAPS certificate
+    win_copy:
+      src: '{{ playbook_dir }}/cert_setup/{{ inventory_hostname | lower }}.pfx'
+      dest: C:\Windows\TEMP\ldaps.pfx
+
+  - name: import LDAPS certificate
+    win_certificate_store:
+      path: C:\Windows\TEMP\ldaps.pfx
+      password: password
+      key_exportable: no
+      key_storage: machine
+      state: present
+      store_type: service
+      store_location: NTDS
+      store_name: My
+    register: ldaps_cert_info
+
+  - name: register LDAPS certificate
+    win_shell: |
+      $dse = [adsi]'LDAP://localhost/rootDSE'
+      [void]$dse.Properties['renewServerCertificate'].Add(1)
+      $dse.CommitChanges()
+    when: ldaps_cert_info is changed
+    vars:
+      ansible_become: yes
+      ansible_become_method: runas
+      ansible_become_user: '{{ domain_user_upn }}'
+      ansible_become_pass: '{{ domain_password }}'

--- a/tests/integration/templates/generate_cert.sh.j2
+++ b/tests/integration/templates/generate_cert.sh.j2
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -o pipefail -eux
+
+PASSWORD="${1}"
+
+generate () {
+    NAME="${1}"
+    SUBJECT="${2}"
+    KEY="${3}"
+    CA_NAME="${4}"
+    CA_OPTIONS=("-CA" "${CA_NAME}.pem" "-CAkey" "${CA_NAME}.key" "-CAcreateserial")
+
+    cat > openssl.conf << EOL
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[req]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = DNS:${SUBJECT}
+EOL
+
+    echo "Generating ${NAME} signed cert"
+    openssl req \
+        -new \
+        "-${KEY}" \
+        -subj "/CN=${SUBJECT}" \
+        -newkey rsa:2048 \
+        -keyout "${NAME}.key" \
+        -out "${NAME}.csr" \
+        -config openssl.conf \
+        -reqexts req \
+        -passin pass:"${PASSWORD}" \
+        -passout pass:"${PASSWORD}"
+
+    openssl x509 \
+        -req \
+        -in "${NAME}.csr" \
+        "-${KEY}" \
+        -out "${NAME}.pem" \
+        -days 365 \
+        -extfile openssl.conf \
+        -extensions req \
+        -passin pass:"${PASSWORD}" \
+        ${CA_OPTIONS[@]}
+
+    openssl pkcs12 \
+        -export \
+        -out "${NAME}.pfx" \
+        -inkey "${NAME}.key" \
+        -in "${NAME}.pem" \
+        -passin pass:"${PASSWORD}" \
+        -passout pass:"${PASSWORD}"
+
+    rm openssl.conf
+}
+
+echo "Generating CA certificate"
+openssl genrsa \
+    -aes256 \
+    -out ca.key \
+    -passout pass:"${PASSWORD}"
+
+openssl req \
+    -new \
+    -x509 \
+    -days 365 \
+    -key ca.key \
+    -out ca.pem \
+    -subj "/CN=PSOpenAD Root" \
+    -passin pass:"${PASSWORD}"
+
+echo "Generating DC01 LDAPS certificate"
+{% for host in ["DC01", "DC02", "DC03"] %}
+generate {{ host | lower }} {{ hostvars[host]["domain_prefix"] | default("") }}{{ domain_name }} sha256 ca
+{% endfor %}
+
+touch complete.txt

--- a/tests/integration/templates/krb5.conf.j2
+++ b/tests/integration/templates/krb5.conf.j2
@@ -1,0 +1,2 @@
+[libdefaults]
+  default_realm = {{ domain_realm | upper }}


### PR DESCRIPTION
Will ensure any search result that contains a referral is emitted as an
error record to the caller. This ensures that the referral isn't lost
and that it provides enough detail for the caller to then resend the
request to the correct server. This replicates how the AD cmdlets work
when a referral is returned.

Also adds a very basic structure for an integration environment to test
out scernarios like referrals. This will hopefully be expanded in the
future to run automated tests and flesh out the environment a bit more.

An example error with this change is

> Get-OpenADUser: A referral was returned from the server that points to: 'ldap://foo.ldap.test/DC=foo,DC=ldap,DC=test'