### PR TITLE
Use background task exceptions as inner exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 + Added error handling for search request that ends with a referral
   + Currently the cmdlet will emit an error record with the referral URI which is similar to what the AD cmdlets do
++ Have exceptions in the background recv thread tasks bubble up as inner exceptions to preserve the stack trace for better debugging
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -57,7 +57,7 @@ internal class OpenADConnection : IDisposable
             // The lock ensures that either the _taskFailure is set on a cancelled operation or the LDAP queue has
             // an entry and set to null for the check later on.
             if (_taskFailure != null)
-                throw _taskFailure;
+                throw new LDAPException($"Message recv failure: {_taskFailure.Message}", _taskFailure);
 
             queue = _messages.GetOrAdd(messageId,
                 new BlockingCollection<LDAPMessage>(new ConcurrentQueue<LDAPMessage>()));
@@ -67,7 +67,7 @@ internal class OpenADConnection : IDisposable
         {
             if (_taskFailure != null)
             {
-                throw _taskFailure;
+                throw new LDAPException($"Message recv failure: {_taskFailure.Message}", _taskFailure);
             }
             else
             {


### PR DESCRIPTION
Instead of throwing the exception from the background as is this change
ensures it is kept as an inner exception. This ensures that the original
exception type and stack trace are preserved making it easier to see
what had failed in the background task.