### PR TITLE
Added -TracePath to New-OpenADSessionOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   + Currently the cmdlet will emit an error record with the referral URI which is similar to what the AD cmdlets do
 + Have exceptions in the background recv thread tasks bubble up as inner exceptions to preserve the stack trace for better debugging
 + Fix authentication with explicit credential on Windows
++ Added `-TracePath` to `New-OpenADSessionOption` to help debug raw LDAP traffice exchanged in a session.
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/docs/en-US/New-OpenADSessionOption.md
+++ b/docs/en-US/New-OpenADSessionOption.md
@@ -14,7 +14,7 @@ Creates an object that contains advanced options for an `OpenAD` session.
 
 ```
 New-OpenADSessionOption [-NoEncryption] [-NoSigning] [-NoChannelBinding] [-SkipCertificateCheck]
- [-ConnectTimeout <Int32>] [-OperationTimeout <Int32>] [<CommonParameters>]
+ [-ConnectTimeout <Int32>] [-OperationTimeout <Int32>] [-TracePath <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,6 +49,18 @@ PS C:\> Get-OpenADUser -Server dc -SessionOption $so -Identity my-username
 
 Disables and encryption or signatures placed on the data exchanged with the LDAP server.
 Encryption and signing is used by auth mechanisms, like `Negotiate` and `Kerberos` to encrypt or sign the data exchanged on the network.
+
+### Example 4: Enable message trace logging
+```powershell
+PS C:\> $so = New-OpenADSessionOption -TracePath temp:/PSOpenAD-Trace.log
+PS C:\> $s = New-OpenADSession -ComputerName dc -SessionOption $so
+PS C:\> Get-OpenADUser -Session $s -Identity my-username
+PS C:\> $s | Remove-OpenADSession
+```
+
+Creates an OpenAD session with trace message logging set to log the incoming and outgoing LDAP messages to `temp:/PSOpenAD-Trace.log`.
+The path can be any location accessible by the `FileSystem` provider in PowerShell.
+The logs will continue to append until the OpenAD session is closed.
 
 ## PARAMETERS
 
@@ -147,6 +159,25 @@ This is useful when the server is using a self signed certificate for it's TLS c
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TracePath
+The path to a local file where incoming and outgoing LDAP messages will be written to.
+Each line in this path starts with either `RECV: ` or `SEND: ` and the value being the base64 encoded string of the LDAP message.
+Opening a new session with a trace path will create the new file path and will overwrite the existing path if it already exists.
+The directory the file is located in must already exist or else the session creation will fail.
+The contents of the LDAP messages can contain sensitive values so use this only for debugging purposes.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/about_OpenADSessions.md
+++ b/docs/en-US/about_OpenADSessions.md
@@ -59,3 +59,14 @@ If the `default_realm` was successfully retrieved (or determined by the local ho
 If any records are returned the default DC is set to the record with the preferred property and weight.
 
 If any of these steps fail then no default DC is available and PSOpenAD is only able to create a connection when an explicit server or connection uri was provided.
+
+# TRACE LOGGING
+It is possible to do trace logging for the raw LDAP messages that are exchanged for debugging purposes.
+To enable trace logging use the `-TracePath` parameter with `New-OpenADSessionOption` when creating a new session.
+
+```powershell
+$so = New-OpenADSessionOption -TracePath temp:/PSOpenAD-trace.log
+Get-OpenADUser -Identity username -SessionOption $so
+```
+
+The trace will remain active for the lifetime of the session.

--- a/src/Commands/OpenADSessionOption.cs
+++ b/src/Commands/OpenADSessionOption.cs
@@ -27,8 +27,17 @@ public class NewOpenADSessionOption : PSCmdlet
     [Parameter()]
     public Int32 OperationTimeout { get; set; } = 180000;
 
+    [Parameter()]
+    public string? TracePath { get; set; }
+
     protected override void EndProcessing()
     {
+        string? tracePath = null;
+        if (!string.IsNullOrWhiteSpace(TracePath))
+        {
+            tracePath = GetUnresolvedProviderPathFromPSPath(TracePath);
+        }
+
         WriteObject(new OpenADSessionOptions()
         {
             NoEncryption = NoEncryption,
@@ -37,6 +46,7 @@ public class NewOpenADSessionOption : PSCmdlet
             SkipCertificateCheck = SkipCertificateCheck,
             ConnectTimeout = ConnectTimeout,
             OperationTimeout = OperationTimeout,
+            TracePath = tracePath,
         });
     }
 }

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -36,6 +36,9 @@ public sealed class OpenADSessionOptions
 
     /// <summary>The maximum time to wait, in milliseconds, to wait for a request to return.</summary>
     public Int32 OperationTimeout { get; set; } = 180000;
+
+    /// <summary>Local path that incoming and outgoing LDAP messages will be logged to.</summary>
+    public string? TracePath { get; set; }
 }
 
 /// <summary>The OpenADSession class used to encapsulate a session with the caller.</summary>
@@ -218,7 +221,7 @@ internal sealed class OpenADSessionFactory
         connectTask.GetAwaiter().GetResult();
 
         OpenADConnection connection = new(client, client.GetStream(), new LDAPSession(),
-            sessionOptions.OperationTimeout);
+            sessionOptions.OperationTimeout, sessionOptions.TracePath);
         try
         {
             bool transportIsTls = false;


### PR DESCRIPTION
Added the `New-OpenADSessionOption -TracePath` option that logs the raw
LDAP messages exchanged in a session. These messages are useful for
debugging problematic exchanges that are not encrypted through TLS or
GSSAPI wrapping.