### PR TITLE
Fix interactive credential prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 + Have exceptions in the background recv thread tasks bubble up as inner exceptions to preserve the stack trace for better debugging
 + Fix authentication with explicit credential on Windows
 + Added `-TracePath` to `New-OpenADSessionOption` to help debug raw LDAP traffice exchanged in a session.
++ Fix credential prompt when specifying `-Credential my-username` for a `PSCredential` parameter
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ You can install this module by running;
 
 ```powershell
 # Install for only the current user
-Install-Module -Name PSOpenAD -Scope CurrentUser
+Install-Module -Name PSOpenAD -Scope CurrentUser -AllowPrerelease
 
 # Install for all users
-Install-Module -Name PSOpenAD -Scope AllUsers
+Install-Module -Name PSOpenAD -Scope AllUsers -AllowPrerelease
 ```
+
+_Note: The module is still in preview so the `-AllowPrerelease` parameter is required._
 
 ## Contributing
 

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -53,6 +53,7 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
 
     [Parameter(ParameterSetName = "ServerIdentity")]
     [Parameter(ParameterSetName = "ServerLDAPFilter")]
+    [Credential()]
     public PSCredential? Credential { get; set; }
 
     #endregion

--- a/src/Commands/OpenADSession.cs
+++ b/src/Commands/OpenADSession.cs
@@ -57,6 +57,7 @@ public class NewOpenADSession : PSCmdlet
     public SwitchParameter UseTLS { get; set; }
 
     [Parameter()]
+    [Credential()]
     public PSCredential? Credential { get; set; }
 
     [Parameter()]

--- a/src/Commands/OpenADWhoami.cs
+++ b/src/Commands/OpenADWhoami.cs
@@ -28,6 +28,7 @@ public class GetOpenADWhoami : PSCmdlet
     public SwitchParameter StartTLS { get; set; }
 
     [Parameter(ParameterSetName = "Server")]
+    [Credential()]
     public PSCredential? Credential { get; set; }
 
     private CancellationTokenSource? CurrentCancelToken { get; set; }

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -390,6 +390,11 @@ internal sealed class OpenADSessionFactory
         AuthenticationMethod auth, PSCredential? credential, ChannelBindings? channelBindings,
         bool transportIsTls, OpenADSessionOptions sessionOptions, CancellationToken cancelToken, PSCmdlet cmdlet)
     {
+        if (credential == PSCredential.Empty)
+        {
+            credential = null;
+        }
+
         if (auth == AuthenticationMethod.Default)
         {
             // Always favour Negotiate auth if it is available, otherwise use Simple if both a credential and the


### PR DESCRIPTION
Ensure the cmdlet will prompt for a credential's password if the
credential is specified as a string. This behaviour is the standard
behaviour for cmdlets that accept a credential and makes it easier for a
user to interactively specify a credential without calling
`Get-Credential` themselves.

Fixes https://github.com/jborean93/PSOpenAD/issues/23
Fixes https://github.com/jborean93/PSOpenAD/issues/24