### PR TITLE
Expand Get-OpenADWhoami Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 + Fix authentication with explicit credential on Windows
 + Added `-TracePath` to `New-OpenADSessionOption` to help debug raw LDAP traffice exchanged in a session.
 + Fix credential prompt when specifying `-Credential my-username` for a `PSCredential` parameter
++ Have `Get-OpenADWhoami` return an object with more details on the LDAP session, like the domain controller DNS name, URI, and authentication method used.
+  + The returned username value will also strip the leading `u:` prefix if it is present
++ Added the `DomainController` property to the `OpenADSession` class to help identify the domain controller the session is connected to
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/docs/en-US/Get-OpenADWhoami.md
+++ b/docs/en-US/Get-OpenADWhoami.md
@@ -1,7 +1,7 @@
 ---
 external help file: PSOpenAD.dll-Help.xml
 Module Name: PSOpenAD
-online version:
+online version: https://www.github.com/jborean93/PSOpenAD/blob/main/docs/en-US/Get-OpenADWhoami.md
 schema: 2.0.0
 ---
 
@@ -170,8 +170,20 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### None
 ## OUTPUTS
 
-### System.String
-The raw whoami response from the server as a string.
+### PSOpenAD.Commands.WhoamiResult
+The `WhoamiResult` object representing the result returned by the LDAP Whoami extended operation plus extra properties to provide extract context on the session. This object will always have the following properties set:
+
++ `UserName`: The username, typically in the netlogon form `DOMAIN\username`, of the authenticated session.
+
++ `Uri`: The LDAP URI used for the connection.
+
++ `DomainController`: The DNS hostname of the domain controller the session is connected to.
+
++ `Authentication`: The authentication method used to authenticate with the session.
+
++ `RawUserName`: The raw string returned from the LDAP whoami extended operation.
+
+The `RawUserName` is not part of the default property sets and will display unless explicitly requested with `Select-Object *` or accessed manually `$result.RawUserName`.
 
 ## NOTES
 

--- a/docs/en-US/New-OpenADSession.md
+++ b/docs/en-US/New-OpenADSession.md
@@ -272,6 +272,8 @@ The connected AD session that can be used as an explicit connection on the vario
 
 + `Authentication`: The authentication method used
 
++ `DomainController`: The DNS hostname of the domain controller that the session is connected to
+
 + `IsSigned`: Whether the data on this connection will be signed
 
 + `IsEncrypted`: Whether the data on this connection will be encrypted

--- a/module/PSOpenAD.Format.ps1xml
+++ b/module/PSOpenAD.Format.ps1xml
@@ -60,6 +60,9 @@
           <TableColumnHeader>
             <Width>15</Width>
           </TableColumnHeader>
+          <TableColumnHeader>
+            <Width>20</Width>
+          </TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
@@ -72,6 +75,49 @@
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>State</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Authentication</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DomainController</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>PSOpenAD.Commands.WhoamiResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSOpenAD.Commands.WhoamiResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Width>25</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Width>20</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Width>20</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Width>15</Width>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>UserName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DomainController</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Uri</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>Authentication</PropertyName>

--- a/src/Commands/OpenADWhoami.cs
+++ b/src/Commands/OpenADWhoami.cs
@@ -1,15 +1,43 @@
 using PSOpenAD.LDAP;
+using System;
 using System.Management.Automation;
 using System.Text;
 using System.Threading;
 
 namespace PSOpenAD.Commands;
 
+/// <summary>The result from a LDAP Whoami request operation.</summary>
+public sealed class WhoamiResult
+{
+    /// <summary>The username without the u: prefix found in the raw result.</summary>
+    public string UserName => RawUserName.StartsWith("u:") ? RawUserName[2..] : RawUserName;
+
+    /// <summary>The LDAP connection URI used for the whoami request.</summary>
+    public Uri Uri { get; }
+
+    /// <summary>The domain controller the request was sent to.</summary>
+    public string DomainController { get; }
+
+    /// <summary>The authentication method used for the LDAP session that did the whoami request.</summary>
+    public AuthenticationMethod Authentication { get; }
+
+    /// <summary>The raw result from the LDAP whoami request.</summary>
+    public string RawUserName { get; }
+
+    internal WhoamiResult(string result, Uri uri, string domainController, AuthenticationMethod authentication)
+    {
+        RawUserName = result;
+        Uri = uri;
+        DomainController = domainController;
+        Authentication = authentication;
+    }
+}
+
 [Cmdlet(
     VerbsCommon.Get, "OpenADWhoami",
     DefaultParameterSetName = "Server"
 )]
-[OutputType(typeof(string))]
+[OutputType(typeof(WhoamiResult))]
 public class GetOpenADWhoami : PSCmdlet
 {
     [Parameter(Mandatory = true, ParameterSetName = "Session")]
@@ -57,7 +85,7 @@ public class GetOpenADWhoami : PSCmdlet
             }
 
             string i = extResp.Value == null ? "Unknown" : Encoding.UTF8.GetString(extResp.Value);
-            WriteObject(i);
+            WriteObject(new WhoamiResult(i, Session.Uri, Session.DomainController, Session.Authentication));
         }
     }
 


### PR DESCRIPTION
Expand the output of `Get-OpenADWhoami` to include a parsed username
response without the leading `u:` and also include other session
information like the domain controller DNS name under
`DomainController`, the LDAP uri used for the connection under `Uri`,
and the authentication method used for the connection under
`Authentication`.

Also include the `DomainController` property on the OpenADSession class
which is based on the `dnsHostName` attribute on the rootDSE queried
when the session was created.

Fixes: https://github.com/jborean93/PSOpenAD/issues/27