### PR TITLE
Add DomainController property on output objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 + Added `-ClientCertificate` to `New-OpenADSessionOption` that is used to authenticate using a client X.509 certificate
 + Raise `UnpackLDAPMessageException` when failing to unpack a response from the server.
   + The exception contains the `LDAPMessage` property which is the raw byte string that was being unpacked.
++ Added the `DomainController` property to the results of any `Get-OpenAD*` objects to help identify what domain controller returned that information
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/docs/en-US/Get-OpenADComputer.md
+++ b/docs/en-US/Get-OpenADComputer.md
@@ -364,6 +364,8 @@ The `OpenADComputer` representing the object(s) found. This object will always h
 
 + `DNSHostName`
 
++ `DomainController`: This is set to the domain controller that processed the request
+
 Any explicit attributes requested through `-Property` are also present on the object.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADGroup.md
+++ b/docs/en-US/Get-OpenADGroup.md
@@ -360,6 +360,8 @@ The `OpenADGroup` representing the object(s) found. This object will always have
 
 + `GroupScope`
 
++ `DomainController`: This is set to the domain controller that processed the request
+
 Any explicit attributes requested through `-Property` are also present on the object.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADObject.md
+++ b/docs/en-US/Get-OpenADObject.md
@@ -347,6 +347,8 @@ The `OpenADObject` representing the object(s) found. This object will always hav
 
 + `ObjectGuid`
 
++ `DomainController`: This is set to the domain controller that processed the request
+
 Any explicit attributes requested through `-Property` are also present on the object.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADServiceAccount.md
+++ b/docs/en-US/Get-OpenADServiceAccount.md
@@ -364,6 +364,8 @@ The `OpenADServiceAccount` representing the object(s) found. This object will al
 
 + `ServicePrincipalNames`
 
++ `DomainController`: This is set to the domain controller that processed the request
+
 Any explicit attributes requested through `-Property` are also present on the object.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADUser.md
+++ b/docs/en-US/Get-OpenADUser.md
@@ -368,6 +368,8 @@ The `OpenADUser` representing the object(s) found. This object will always have 
 
 + `Surname`
 
++ `DomainController`: This is set to the domain controller that processed the request
+
 Any explicit attributes requested through `-Property` are also present on the object.
 
 ## NOTES

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -205,8 +205,10 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
                 OpenADObject adObj = CreateADObject(props);
 
                 // This adds a note property for each explicitly requested property, excluding the ones the object
-                // naturally exposes.
+                // naturally exposes. Also adds the DomainController property to denote what DC the response came from.
                 PSObject adPSObj = PSObject.AsPSObject(adObj);
+                adPSObj.Properties.Add(new PSNoteProperty("DomainController", Session.DomainController));
+
                 List<string> orderedProps = props.Keys
                     .Where(v =>
                         (showAll || explicitProperties.Contains(v, comparer)) &&

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -15,10 +15,17 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
 
     Context "Get-OpenADObject" {
         It "Creates session using hostname" {
-            Get-OpenADObject -Server $PSOpenADSettings.Server | Out-Null
+            $actual = Get-OpenADObject -Server $PSOpenADSettings.Server
+            $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+                $_.PSObject.Properties.Name | Should -Contain 'Name'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+                $_.DomainController | Should -Be $PSOpenADSettings.Server
+            }
         }
 
-        It "Creates sessoin using hostname:port" {
+        It "Creates session using hostname:port" {
             Get-OpenADObject -Server "$($PSOpenADSettings.Server):389" | Out-Null
         }
 
@@ -42,6 +49,19 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $actual = Get-OpenADComputer -Session $session -Identity $dcName
             $actual.Name | Should -Be $dcName
             $actual.SamAccountName | Should -Be "$dcName$"
+
+            $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+                $_.PSObject.Properties.Name | Should -Contain 'Name'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+                $_.PSObject.Properties.Name | Should -Contain 'DNSHostName'
+                $_.PSObject.Properties.Name | Should -Contain 'Enabled'
+                $_.PSObject.Properties.Name | Should -Contain 'UserPrincipalName'
+                $_.PSObject.Properties.Name | Should -Contain 'SamAccountName'
+                $_.PSObject.Properties.Name | Should -Contain 'SID'
+                $_.DomainController | Should -Be $PSOpenADSettings.Server
+            }
         }
 
         It "Finds ADComputer by -Identity sAMAccountName" {
@@ -72,6 +92,37 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $actual.Count | Should -Be 2
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADGroup])
             $actual[1] | Should -BeOfType ([PSOpenAD.OpenADGroup])
+
+            $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+                $_.PSObject.Properties.Name | Should -Contain 'Name'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+                $_.PSObject.Properties.Name | Should -Contain 'GroupCategory'
+                $_.PSObject.Properties.Name | Should -Contain 'GroupScope'
+                $_.PSObject.Properties.Name | Should -Contain 'SamAccountName'
+                $_.PSObject.Properties.Name | Should -Contain 'SID'
+                $_.DomainController | Should -Be $PSOpenADSettings.Server
+            }
+        }
+    }
+
+    Context "Get-OpenADUser" {
+        It "Finds ADUser" {
+            $actual = Get-OpenADUser -Session $session
+            $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+                $_.PSObject.Properties.Name | Should -Contain 'Name'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+                $_.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+                $_.PSObject.Properties.Name | Should -Contain 'GivenName'
+                $_.PSObject.Properties.Name | Should -Contain 'Surname'
+                $_.PSObject.Properties.Name | Should -Contain 'Enabled'
+                $_.PSObject.Properties.Name | Should -Contain 'UserPrincipalName'
+                $_.PSObject.Properties.Name | Should -Contain 'SamAccountName'
+                $_.PSObject.Properties.Name | Should -Contain 'SID'
+                $_.DomainController | Should -Be $PSOpenADSettings.Server
+            }
         }
 
         It "Uses default ldap filter with -SearchBase" {


### PR DESCRIPTION
Added the `DomainController` property to the output objects of any
`Get-OpenAD*` cmdlets. This allows the caller to determine the source of
the LDAP response and compare requests coming from different domain
controllers.

I'm not 100% sure whether this should be done as a note property similar to how `Invoke-Command` add `PSComputerName` to the results. Maybe that also means the property should be `PSDomainController` and added as a note property rather than being a property on the class itself.

Fixes: https://github.com/jborean93/PSOpenAD/issues/28