### PR TITLE
Fix default parameter sets for Get-OpenAD* cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 + Have `Get-OpenADWhoami` return an object with more details on the LDAP session, like the domain controller DNS name, URI, and authentication method used.
   + The returned username value will also strip the leading `u:` prefix if it is present
 + Added the `DomainController` property to the `OpenADSession` class to help identify the domain controller the session is connected to
++ Fixed the default parameter sets of the `Get-OpenAD*` cmdlets to always use the default LDAP filter that selects all of that type unless an explicit filter or identity was provided
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/docs/en-US/Get-OpenADComputer.md
+++ b/docs/en-US/Get-OpenADComputer.md
@@ -12,30 +12,30 @@ Get one or more Active Directory computers.
 
 ## SYNTAX
 
-### ServerIdentity (Default)
+### ServerLDAPFilter (Default)
 ```
 Get-OpenADComputer [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
- [[-Identity] <ADPrincipalIdentityWithDollar>] [-Property <String[]>] [<CommonParameters>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-LDAPFilter <String>]
+ [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADComputer -Session <OpenADSession> [[-Identity] <ADPrincipalIdentityWithDollar>]
- [-Property <String[]>] [<CommonParameters>]
+Get-OpenADComputer -Session <OpenADSession> [-Identity] <ADPrincipalIdentityWithDollar> [-Property <String[]>]
+ [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
 ```
-Get-OpenADComputer -Session <OpenADSession> -LDAPFilter <String> [-SearchBase <String>]
+Get-OpenADComputer -Session <OpenADSession> [-LDAPFilter <String>] [-SearchBase <String>]
  [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
-### ServerLDAPFilter
+### ServerIdentity
 ```
 Get-OpenADComputer [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] -LDAPFilter <String>
- [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
+ [-Identity] <ADPrincipalIdentityWithDollar> [-Property <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -108,7 +108,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: AuthenticationMethod
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos
 
@@ -125,7 +125,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -154,10 +154,10 @@ The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
 Type: ADPrincipalIdentityWithDollar
-Parameter Sets: ServerIdentity, SessionIdentity
+Parameter Sets: SessionIdentity, ServerIdentity
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
@@ -170,10 +170,10 @@ The filter specified here will be used with an `AND` condition to `(objectCatego
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -229,7 +229,7 @@ Combine this with `-SearchScope` to limit searches to a smaller subset of the do
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
 Required: False
@@ -251,7 +251,7 @@ This can be set to
 
 ```yaml
 Type: SearchScope
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 Accepted values: Base, OneLevel, Subtree
 
@@ -273,7 +273,7 @@ This option is mutually exclusive with `-Session`.
 
 ```yaml
 Type: String
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -307,7 +307,7 @@ These options can be generated with `New-OpenADSessionOption`.
 
 ```yaml
 Type: OpenADSessionOptions
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -322,7 +322,7 @@ Use `StartTLS` when creating a new session with `-Server`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False

--- a/docs/en-US/Get-OpenADGroup.md
+++ b/docs/en-US/Get-OpenADGroup.md
@@ -12,30 +12,30 @@ Gets one or more Active Directory groups.
 
 ## SYNTAX
 
-### ServerIdentity (Default)
+### ServerLDAPFilter (Default)
 ```
 Get-OpenADGroup [-Server <String>] [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>]
- [-StartTLS] [-Credential <PSCredential>] [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
- [<CommonParameters>]
+ [-StartTLS] [-Credential <PSCredential>] [-LDAPFilter <String>] [-SearchBase <String>]
+ [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADGroup -Session <OpenADSession> [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
+Get-OpenADGroup -Session <OpenADSession> [-Identity] <ADPrincipalIdentity> [-Property <String[]>]
  [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
 ```
-Get-OpenADGroup -Session <OpenADSession> -LDAPFilter <String> [-SearchBase <String>]
+Get-OpenADGroup -Session <OpenADSession> [-LDAPFilter <String>] [-SearchBase <String>]
  [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
-### ServerLDAPFilter
+### ServerIdentity
 ```
 Get-OpenADGroup [-Server <String>] [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>]
- [-StartTLS] [-Credential <PSCredential>] -LDAPFilter <String> [-SearchBase <String>]
- [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+ [-StartTLS] [-Credential <PSCredential>] [-Identity] <ADPrincipalIdentity> [-Property <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -108,7 +108,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: AuthenticationMethod
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos
 
@@ -125,7 +125,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -154,10 +154,10 @@ The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
 Type: ADPrincipalIdentity
-Parameter Sets: ServerIdentity, SessionIdentity
+Parameter Sets: SessionIdentity, ServerIdentity
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
@@ -170,10 +170,10 @@ The filter specified here will be used with an `AND` condition to `(objectCatego
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -227,7 +227,7 @@ Combine this with `-SearchScope` to limit searches to a smaller subset of the do
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
 Required: False
@@ -249,7 +249,7 @@ This can be set to
 
 ```yaml
 Type: SearchScope
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 Accepted values: Base, OneLevel, Subtree
 
@@ -271,7 +271,7 @@ This option is mutually exclusive with `-Session`.
 
 ```yaml
 Type: String
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -305,7 +305,7 @@ These options can be generated with `New-OpenADSessionOption`.
 
 ```yaml
 Type: OpenADSessionOptions
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -320,7 +320,7 @@ Use `StartTLS` when creating a new session with `-Server`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False

--- a/docs/en-US/Get-OpenADObject.md
+++ b/docs/en-US/Get-OpenADObject.md
@@ -12,30 +12,30 @@ Gets one or more Active Directory objects.
 
 ## SYNTAX
 
-### ServerIdentity (Default)
+### ServerLDAPFilter (Default)
 ```
 Get-OpenADObject [-IncludeDeletedObjects] [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
- [-Identity <ADObjectIdentity>] [-Property <String[]>] [<CommonParameters>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-LDAPFilter <String>]
+ [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADObject [-IncludeDeletedObjects] -Session <OpenADSession> [-Identity <ADObjectIdentity>]
+Get-OpenADObject [-IncludeDeletedObjects] -Session <OpenADSession> -Identity <ADObjectIdentity>
  [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
 ```
-Get-OpenADObject [-IncludeDeletedObjects] -Session <OpenADSession> -LDAPFilter <String> [-SearchBase <String>]
- [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+Get-OpenADObject [-IncludeDeletedObjects] -Session <OpenADSession> [-LDAPFilter <String>]
+ [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
-### ServerLDAPFilter
+### ServerIdentity
 ```
 Get-OpenADObject [-IncludeDeletedObjects] [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] -LDAPFilter <String>
- [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] -Identity <ADObjectIdentity>
+ [-Property <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -99,7 +99,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: AuthenticationMethod
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos
 
@@ -116,7 +116,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -138,10 +138,10 @@ The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
 Type: ADObjectIdentity
-Parameter Sets: ServerIdentity, SessionIdentity
+Parameter Sets: SessionIdentity, ServerIdentity
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
@@ -173,10 +173,10 @@ Used instead of `-Identity` to specify an LDAP query used to filter objects.
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -224,7 +224,7 @@ Combine this with `-SearchScope` to limit searches to a smaller subset of the do
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
 Required: False
@@ -246,7 +246,7 @@ This can be set to
 
 ```yaml
 Type: SearchScope
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
 Required: False
@@ -267,7 +267,7 @@ This option is mutually exclusive with `-Session`.
 
 ```yaml
 Type: String
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -301,7 +301,7 @@ These options can be generated with `New-OpenADSessionOption`.
 
 ```yaml
 Type: OpenADSessionOptions
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -316,7 +316,7 @@ Use `StartTLS` when creating a new session with `-Server`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False

--- a/docs/en-US/Get-OpenADServiceAccount.md
+++ b/docs/en-US/Get-OpenADServiceAccount.md
@@ -12,30 +12,30 @@ Gets one or more Active Directory managed service accounts or group managed serv
 
 ## SYNTAX
 
-### ServerIdentity (Default)
+### ServerLDAPFilter (Default)
 ```
 Get-OpenADServiceAccount [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
- [[-Identity] <ADPrincipalIdentityWithDollar>] [-Property <String[]>] [<CommonParameters>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-LDAPFilter <String>]
+ [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADServiceAccount -Session <OpenADSession> [[-Identity] <ADPrincipalIdentityWithDollar>]
+Get-OpenADServiceAccount -Session <OpenADSession> [-Identity] <ADPrincipalIdentityWithDollar>
  [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
 ```
-Get-OpenADServiceAccount -Session <OpenADSession> -LDAPFilter <String> [-SearchBase <String>]
+Get-OpenADServiceAccount -Session <OpenADSession> [-LDAPFilter <String>] [-SearchBase <String>]
  [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
-### ServerLDAPFilter
+### ServerIdentity
 ```
 Get-OpenADServiceAccount [-Server <String>] [-AuthType <AuthenticationMethod>]
- [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] -LDAPFilter <String>
- [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
+ [-Identity] <ADPrincipalIdentityWithDollar> [-Property <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -108,7 +108,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: AuthenticationMethod
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos
 
@@ -125,7 +125,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -154,10 +154,10 @@ The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
 Type: ADPrincipalIdentityWithDollar
-Parameter Sets: ServerIdentity, SessionIdentity
+Parameter Sets: SessionIdentity, ServerIdentity
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
@@ -170,10 +170,10 @@ The filter specified here will be used with an `AND` condition to `(objectCatego
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -229,7 +229,7 @@ Combine this with `-SearchScope` to limit searches to a smaller subset of the do
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
 Required: False
@@ -251,7 +251,7 @@ This can be set to
 
 ```yaml
 Type: SearchScope
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 Accepted values: Base, OneLevel, Subtree
 
@@ -273,7 +273,7 @@ This option is mutually exclusive with `-Session`.
 
 ```yaml
 Type: String
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -307,7 +307,7 @@ These options can be generated with `New-OpenADSessionOption`.
 
 ```yaml
 Type: OpenADSessionOptions
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -322,7 +322,7 @@ Use `StartTLS` when creating a new session with `-Server`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False

--- a/docs/en-US/Get-OpenADUser.md
+++ b/docs/en-US/Get-OpenADUser.md
@@ -12,30 +12,30 @@ Gets one or more Active Directory users.
 
 ## SYNTAX
 
-### ServerIdentity (Default)
+### ServerLDAPFilter (Default)
 ```
 Get-OpenADUser [-Server <String>] [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>]
- [-StartTLS] [-Credential <PSCredential>] [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
- [<CommonParameters>]
+ [-StartTLS] [-Credential <PSCredential>] [-LDAPFilter <String>] [-SearchBase <String>]
+ [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADUser -Session <OpenADSession> [[-Identity] <ADPrincipalIdentity>] [-Property <String[]>]
+Get-OpenADUser -Session <OpenADSession> [-Identity] <ADPrincipalIdentity> [-Property <String[]>]
  [<CommonParameters>]
 ```
 
 ### SessionLDAPFilter
 ```
-Get-OpenADUser -Session <OpenADSession> -LDAPFilter <String> [-SearchBase <String>]
+Get-OpenADUser -Session <OpenADSession> [-LDAPFilter <String>] [-SearchBase <String>]
  [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
-### ServerLDAPFilter
+### ServerIdentity
 ```
 Get-OpenADUser [-Server <String>] [-AuthType <AuthenticationMethod>] [-SessionOption <OpenADSessionOptions>]
- [-StartTLS] [-Credential <PSCredential>] -LDAPFilter <String> [-SearchBase <String>]
- [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+ [-StartTLS] [-Credential <PSCredential>] [-Identity] <ADPrincipalIdentity> [-Property <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -108,7 +108,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: AuthenticationMethod
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos
 
@@ -125,7 +125,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -154,10 +154,10 @@ The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
 Type: ADPrincipalIdentity
-Parameter Sets: ServerIdentity, SessionIdentity
+Parameter Sets: SessionIdentity, ServerIdentity
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
@@ -170,10 +170,10 @@ The filter specified here will be used with an `AND` condition to `(objectCatego
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -231,7 +231,7 @@ Combine this with `-SearchScope` to limit searches to a smaller subset of the do
 
 ```yaml
 Type: String
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 
 Required: False
@@ -253,7 +253,7 @@ This can be set to
 
 ```yaml
 Type: SearchScope
-Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, SessionLDAPFilter
 Aliases:
 Accepted values: Base, OneLevel, Subtree
 
@@ -275,7 +275,7 @@ This option is mutually exclusive with `-Session`.
 
 ```yaml
 Type: String
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -309,7 +309,7 @@ These options can be generated with `New-OpenADSessionOption`.
 
 ```yaml
 Type: OpenADSessionOptions
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False
@@ -324,7 +324,7 @@ Use `StartTLS` when creating a new session with `-Server`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerIdentity, ServerLDAPFilter
+Parameter Sets: ServerLDAPFilter, ServerIdentity
 Aliases:
 
 Required: False

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -61,16 +61,14 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
     #region LDAPFilter Parameters
 
     [Parameter(
-        Mandatory = true,
         ValueFromPipelineByPropertyName = true,
         ParameterSetName = "ServerLDAPFilter"
     )]
     [Parameter(
-        Mandatory = true,
         ValueFromPipelineByPropertyName = true,
         ParameterSetName = "SessionLDAPFilter"
     )]
-    public string LDAPFilter { get; set; } = "";
+    public string? LDAPFilter { get; set; }
 
     [Parameter(ParameterSetName = "ServerLDAPFilter")]
     [Parameter(ParameterSetName = "SessionLDAPFilter")]
@@ -82,21 +80,27 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
 
     #endregion
 
-    #region Common Parameters
+    #region Identity Parameters
 
     [Parameter(
+        Mandatory = true,
         Position = 0,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true,
         ParameterSetName = "ServerIdentity"
     )]
     [Parameter(
+        Mandatory = true,
         Position = 0,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true,
         ParameterSetName = "SessionIdentity"
     )]
     public T? Identity { get; set; }
+
+    #endregion
+
+    #region Common Parameters
 
     [Parameter()]
     [Alias("Properties")]
@@ -109,7 +113,7 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
     protected override void ProcessRecord()
     {
         LDAPFilter finalFilter;
-        if (ParameterSetName.EndsWith("LDAPFilter"))
+        if (!string.IsNullOrWhiteSpace(LDAPFilter))
         {
             LDAPFilter subFilter;
             try
@@ -243,7 +247,7 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
 
 [Cmdlet(
     VerbsCommon.Get, "OpenADObject",
-    DefaultParameterSetName = "ServerIdentity"
+    DefaultParameterSetName = "ServerLDAPFilter"
 )]
 [OutputType(typeof(OpenADObject))]
 public class GetOpenADObject : GetOpenADOperation<ADObjectIdentity>
@@ -261,7 +265,7 @@ public class GetOpenADObject : GetOpenADOperation<ADObjectIdentity>
 
 [Cmdlet(
     VerbsCommon.Get, "OpenADComputer",
-    DefaultParameterSetName = "ServerIdentity"
+    DefaultParameterSetName = "ServerLDAPFilter"
 )]
 [OutputType(typeof(OpenADComputer))]
 public class GetOpenADComputer : GetOpenADOperation<ADPrincipalIdentityWithDollar>
@@ -277,7 +281,7 @@ public class GetOpenADComputer : GetOpenADOperation<ADPrincipalIdentityWithDolla
 
 [Cmdlet(
     VerbsCommon.Get, "OpenADUser",
-    DefaultParameterSetName = "ServerIdentity"
+    DefaultParameterSetName = "ServerLDAPFilter"
 )]
 [OutputType(typeof(OpenADUser))]
 public class GetOpenADUser : GetOpenADOperation<ADPrincipalIdentity>
@@ -293,7 +297,7 @@ public class GetOpenADUser : GetOpenADOperation<ADPrincipalIdentity>
 
 [Cmdlet(
     VerbsCommon.Get, "OpenADGroup",
-    DefaultParameterSetName = "ServerIdentity"
+    DefaultParameterSetName = "ServerLDAPFilter"
 )]
 [OutputType(typeof(OpenADGroup))]
 public class GetOpenADGroup : GetOpenADOperation<ADPrincipalIdentity>
@@ -309,7 +313,7 @@ public class GetOpenADGroup : GetOpenADOperation<ADPrincipalIdentity>
 
 [Cmdlet(
     VerbsCommon.Get, "OpenADServiceAccount",
-    DefaultParameterSetName = "ServerIdentity"
+    DefaultParameterSetName = "ServerLDAPFilter"
 )]
 [OutputType(typeof(OpenADServiceAccount))]
 public class GetOpenADServiceAccount : GetOpenADOperation<ADPrincipalIdentityWithDollar>

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -28,6 +28,13 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
                 Get-OpenADObject -Server hostname:port -ErrorAction Stop
             } | Should -Throw -ExceptionType ([ArgumentException]) -ExpectedMessage $expected
         }
+
+        It "Uses default ldap filter with -SearchBase" {
+            $allObjects = Get-OpenADObject -Session $session
+            $searchObjects = Get-OpenADObject -Session $session -SearchBase $session.DefaultNamingContext
+
+            $allObjects.Count | Should -Be $searchObjects.Count
+        }
     }
 
     Context "Get-OpenADComputer" {
@@ -50,6 +57,13 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $actual[1] | Should -BeOfType ([PSOpenAD.OpenADComputer])
             $actual[0].ObjectGuid | Should -Be $actual[1].ObjectGuid
         }
+
+        It "Uses default ldap filter with -SearchBase" {
+            $allObjects = Get-OpenADComputer -Session $session
+            $searchObjects = Get-OpenADComputer -Session $session -SearchBase $session.DefaultNamingContext
+
+            $allObjects.Count | Should -Be $searchObjects.Count
+        }
     }
 
     Context "Get-OpenADGroup" {
@@ -58,6 +72,13 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $actual.Count | Should -Be 2
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADGroup])
             $actual[1] | Should -BeOfType ([PSOpenAD.OpenADGroup])
+        }
+
+        It "Uses default ldap filter with -SearchBase" {
+            $allObjects = Get-OpenADGroup -Session $session
+            $searchObjects = Get-OpenADGroup -Session $session -SearchBase $session.DefaultNamingContext
+
+            $allObjects.Count | Should -Be $searchObjects.Count
         }
     }
 }


### PR DESCRIPTION
Fixes the default parameter set used for the Get-OpenAD* cmdlets so that
the default LDAPFilter that selects all of that type is always applied
unless an explicit filter was specified or an identity was specified.
This means setting a search base will no longer prompt for a filter to
use.

Fixes https://github.com/jborean93/PSOpenAD/issues/29