### PR TITLE
Implement Certificate authentication 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   + The returned username value will also strip the leading `u:` prefix if it is present
 + Added the `DomainController` property to the `OpenADSession` class to help identify the domain controller the session is connected to
 + Fixed the default parameter sets of the `Get-OpenAD*` cmdlets to always use the default LDAP filter that selects all of that type unless an explicit filter or identity was provided
++ Added `-ClientCertificate` to `New-OpenADSessionOption` that is used to authenticate using a client X.509 certificate
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/docs/en-US/New-OpenADSessionOption.md
+++ b/docs/en-US/New-OpenADSessionOption.md
@@ -14,7 +14,8 @@ Creates an object that contains advanced options for an `OpenAD` session.
 
 ```
 New-OpenADSessionOption [-NoEncryption] [-NoSigning] [-NoChannelBinding] [-SkipCertificateCheck]
- [-ConnectTimeout <Int32>] [-OperationTimeout <Int32>] [-TracePath <String>] [<CommonParameters>]
+ [-ConnectTimeout <Int32>] [-OperationTimeout <Int32>] [-TracePath <String>]
+ [-ClientCertificate <X509Certificate>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,7 +63,38 @@ Creates an OpenAD session with trace message logging set to log the incoming and
 The path can be any location accessible by the `FileSystem` provider in PowerShell.
 The logs will continue to append until the OpenAD session is closed.
 
+### Example 5: Connect using Certificate authentication
+```powershell
+PS C:\> $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new('Cert Path.pfx', $certPass)
+PS C:\> $so = New-OpenADSessionOption -ClientCertificate $cert
+PS C:\> $s = New-OpenADSession -ComputerName dc -SessionOption $so -UseTLS
+```
+
+Creates an OpenAD session to an `LDAPS` endpoint and authenticates using the client certificate provided.
+This certificate needs to be mapped to a user on the server for the authentication to occur.
+
 ## PARAMETERS
+
+### -ClientCertificate
+The X.509 certificate to be used for the TLS client authentication.
+This is used for the `Certificate` authentication mechanism with the LDAP server using `StartTLS` or over `LDAPS`.
+The certificate must have access to the private key for it to be used with authentication.
+See the [X509Certificate constructors](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate.-ctor?view=net-6.0) to see how to create this object from a file.
+
+The certificate specified needs to be mapped to an account that is used for authorization checks.
+This mapping can be done either implicitly through a user cert requested by Active Directory Certificate Services (ADCS) or through an explicit mapping on the user object.
+
+```yaml
+Type: X509Certificate
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ConnectTimeout
 The timeout in milliseconds that the client will wait to connect to the target host.

--- a/docs/en-US/about_OpenADAuthentication.md
+++ b/docs/en-US/about_OpenADAuthentication.md
@@ -56,6 +56,17 @@ The data is still encrypted or signed by default it just requires less network r
 Negotiate authentication over LDAP refers to the `GSS-SPNEGO` mechanism.
 It is recommended to use Negotiate auth over Kerberos unless only Kerberos authentication is desired.
 
+# CERTIFICATE AUTH
+Certificate authentication uses an X.509 certificate presented by the client that used for authenticatoin.
+Typically this certificate is mapped to an account on the server.
+For Microsoft Active Directory servers, the certificate is either created by the Active Directory Certificate Services for a user, implicit mapping.
+It could also be a certificate that is manually mapped to a domain account and trusted in the `NTAuthStore`, explicit mapping.
+The client provides a certificate containing a private key for use with the TLS handshake and the identity the certificate is mapped to is used for authentication.
+This client certificate is set through the `New-OpenADSessionOption -ClientCertificate $cert` parameter when creating the session.
+
+Certificate authentication over LDAP refers to the `EXTERNAL` mechanism.
+This can only be used when communicating over LDAP with `StartTLS` enabled or an `LDAPS` connection.
+
 # ENCRYPTION
 While `StartTLS` or `LDAPS` connections will encrypt all the LDAP traffic between the client and server, normal `LDAP` connections use the authentication provider to provide encryption/signing.
 Neither the `Anonymous` or `Simple` authentication method can encrypt/sign the data and thus should only be used on a `StartTLS` or `LDAPS` connection.

--- a/src/Commands/OpenADSessionOption.cs
+++ b/src/Commands/OpenADSessionOption.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Management.Automation;
+using System.Security.Cryptography.X509Certificates;
 
 namespace PSOpenAD.Commands;
 
@@ -30,6 +31,9 @@ public class NewOpenADSessionOption : PSCmdlet
     [Parameter()]
     public string? TracePath { get; set; }
 
+    [Parameter()]
+    public X509Certificate? ClientCertificate { get; set; }
+
     protected override void EndProcessing()
     {
         string? tracePath = null;
@@ -47,6 +51,7 @@ public class NewOpenADSessionOption : PSCmdlet
             ConnectTimeout = ConnectTimeout,
             OperationTimeout = OperationTimeout,
             TracePath = tracePath,
+            ClientCertificate = ClientCertificate,
         });
     }
 }

--- a/src/OnImportAndRemove.cs
+++ b/src/OnImportAndRemove.cs
@@ -96,6 +96,8 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
             true, false, "");
         GlobalState.Providers[AuthenticationMethod.Simple] = new(AuthenticationMethod.Simple, "PLAIN", true,
             false, "");
+        GlobalState.Providers[AuthenticationMethod.Certificate] = new(AuthenticationMethod.Certificate, "EXTERNAL",
+            true, true, "");
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -77,6 +77,74 @@
     win_reboot:
     when: domain_setup_res.reboot_required
 
+  - name: install Active Directory Certificate Services
+    win_feature:
+      name: AD-Certificate
+      state: present
+    register: adcs_setup_res
+
+  - name: reboot after ADCS install
+    win_reboot:
+    when: adcs_setup_res.reboot_required
+
+  - name: configure ADCS certification authority
+    ansible.windows.win_powershell:
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        $caParams = @{
+            CAType             = 'EnterpriseRootCa'
+            CryptoProviderName = 'RSA#Microsoft Software Key Storage Provider'
+            KeyLength          = 2048
+            HashAlgorithmName  = 'SHA256'
+            Force              = $true
+        }
+        try {
+            Install-AdcsCertificationAuthority @caParams
+            $Ansible.Changed = $true
+        }
+        catch [Microsoft.CertificateServices.Deployment.Common.CertificateServicesBaseSetupException] {
+            if ($_.Exception.Message -like 'The Certification Authority is already installed.*') {
+                return
+            }
+            throw
+        }
+
+    become: yes
+    become_method: runas
+    become_user: SYSTEM
+
+  - name: add custom CA to Forest NTAuthStore
+    ansible.windows.win_powershell:
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        $caCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new('C:\Windows\TEMP\ca.pem')
+        $configRoot = (Get-ADRootDSE).configurationNamingContext
+
+        $dn = "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,$configRoot"
+        $obj = Get-ADObject -Identity $dn -Properties cACertificate
+
+        $found = $false
+        foreach ($certBytes in $obj.cACertificate) {
+            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certBytes)
+            if ($cert.Thumbprint -eq $caCert.Thumbprint) {
+                $found = $true
+                break
+            }
+        }
+
+        if (-not $found) {
+            certutil.exe -dspublish C:\Windows\TEMP\ca.pem NTAuthCA
+            $Ansible.Changed = $true
+        }
+
+    become: yes
+    become_method: runas
+    become_user: SYSTEM
+
   - name: create domain username
     win_domain_user:
       name: '{{ domain_username }}'
@@ -89,6 +157,52 @@
       - Domain Admins
       - Enterprise Admins
       state: present
+
+  - name: request User certificate
+    ansible.windows.win_powershell:
+      parameters:
+        Path: C:\Windows\TEMP\user-{{ domain_username }}.pfx
+        CertPass: '{{ domain_password }}'
+      script: |
+        [CmdletBinding()]
+        param (
+            [string]
+            $Path,
+
+            [string]
+            $CertPass
+        )
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        if (Test-Path -LiteralPath $Path) {
+            return
+        }
+
+        Push-Location Cert:\CurrentUser\My
+        $result = Get-Certificate -Template User -Url ldap:
+        Pop-Location
+
+        if ($result.Status -ne "Issued") {
+            throw "Failed to request User certificate: $($result.Status)"
+        }
+        $Ansible.Changed = $true
+
+        $cert = $result.Certificate
+        $certBytes = $result.Certificate.Export("Pfx", $CertPass)
+        [System.IO.File]::WriteAllBytes($Path, $certBytes)
+
+    become: yes
+    become_method: runas
+    vars:
+      ansible_become_user: '{{ domain_user_upn }}'
+      ansible_become_pass: '{{ domain_password }}'
+
+  - name: fetch certificate for user cert authentication
+    fetch:
+      src: C:\Windows\TEMP\user-{{ domain_username }}.pfx
+      dest: '{{ playbook_dir }}/cert_setup/user-{{ domain_username }}.pfx'
+      flat: yes
 
   - name: copy LDAPS certificate
     win_copy:


### PR DESCRIPTION
Adds support for Certificate authentication using the SASL EXTERNAL
mechanism. This allows the caller to authenticate against an LDAP
instance using StartTLS or LDAPS with an explicitly provided X.509
client certificate.

Unfortunately it doesn't look like Samba offers a way to use certificate authentication so this cannot be fully tested in CI. I have added the setup tasks in the integration playbook to test out this scenario with an actual Active Directory host though. This just needs better integration to run tests against but it does work.