### PR TITLE
Add UnpackLDAPMessageException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 + Added the `DomainController` property to the `OpenADSession` class to help identify the domain controller the session is connected to
 + Fixed the default parameter sets of the `Get-OpenAD*` cmdlets to always use the default LDAP filter that selects all of that type unless an explicit filter or identity was provided
 + Added `-ClientCertificate` to `New-OpenADSessionOption` that is used to authenticate using a client X.509 certificate
++ Raise `UnpackLDAPMessageException` when failing to unpack a response from the server.
+  + The exception contains the `LDAPMessage` property which is the raw byte string that was being unpacked.
 
 ## v0.1.0-preview3 - 2022-03-22
 

--- a/src/LDAP/Error.cs
+++ b/src/LDAP/Error.cs
@@ -197,3 +197,22 @@ public class LDAPException : Exception
         _ => "Unknown error",
     };
 }
+
+public class UnpackLDAPMessageException : Exception
+{
+    public byte[] LDAPMessage { get; } = Array.Empty<byte>();
+
+    public UnpackLDAPMessageException() { }
+
+    public UnpackLDAPMessageException(string message) : base(message) { }
+
+    public UnpackLDAPMessageException(string message, Exception innerException) :
+        base(message, innerException)
+    { }
+
+    public UnpackLDAPMessageException(string message, byte[] ldapMessage, Exception innerException) :
+        base(message, innerException)
+    {
+        LDAPMessage = ldapMessage;
+    }
+}

--- a/tests/units/LDAPMessageTests.cs
+++ b/tests/units/LDAPMessageTests.cs
@@ -47,4 +47,30 @@ public static class LDAPMessageTests
         Assert.Single(actual.Result.Referrals);
         Assert.Equal("ldap://foo.ldap.test/DC=foo,DC=ldap,DC=test", actual.Result.Referrals?[0]);
     }
+
+    [Fact]
+    public static void FailToUnpackMessageInvalidNotASequence()
+    {
+        const string MESSAGE = "BAR0ZXN0";
+        LDAPSession session = new();
+
+        var ex = Assert.Throws<UnpackLDAPMessageException>(() => session.ReceiveData(Convert.FromBase64String(MESSAGE), out var _));
+
+        Assert.Equal("Failed to unpack LDAP message: The provided data is tagged with 'Universal' class value '4', but it should have been 'Universal' class value '16'.",
+            ex.Message);
+        Assert.Equal(ex.LDAPMessage, Convert.FromBase64String(MESSAGE));
+    }
+
+    [Fact]
+    public static void FailToUnpackMessageInvalidNotAValidLDAPMsgExtraData()
+    {
+        const string MESSAGE = "MAR0ZXN0dGVzdA==";
+        LDAPSession session = new();
+
+        var ex = Assert.Throws<UnpackLDAPMessageException>(() => session.ReceiveData(Convert.FromBase64String(MESSAGE), out var _));
+
+        Assert.Equal("Failed to unpack LDAP message: The provided data is tagged with 'Application' class value '20', but it should have been 'Universal' class value '2'.",
+            ex.Message);
+        Assert.Equal(ex.LDAPMessage, Convert.FromBase64String(MESSAGE[..8]));
+    }
 }


### PR DESCRIPTION
Add UnpackLDAPMessageException which is raised when the LDAP session is
unable to unpack a response from the server. This exception contains the
raw byte array of the message that was being processed making it
possible to get the message details for further debugging without
enabling message tracing.