### PR TITLE
Fix ASN1 Length detection code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSOpenAD
 
+## v0.1.0-preview5 - TBD
+
++ Fix up edge case for calculating input LDAP message lengths causing an unpack exception
+
 ## v0.1.0-preview4 - 2022-06-15
 
 + Added error handling for search request that ends with a referral

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -95,7 +95,7 @@
 
         PSData = @{
 
-            Prerelease   = 'preview4'
+            Prerelease   = 'preview5'
 
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags         = @(

--- a/src/LDAP/Asn1.cs
+++ b/src/LDAP/Asn1.cs
@@ -65,13 +65,14 @@ internal static class Asn1Helper
         uint length = 0;
         for (int i = 0; i < lengthLength; i++)
         {
-            byte currentOctet = data.Slice(i, 1 + i).ToArray()[0];
+            byte currentOctet = data[..1].ToArray()[0];
 
             if (length == 0 && currentOctet != 0 && lengthLength - i > sizeof(int))
                 throw new AsnContentException("ASN.1 content contains too much data to decode");
 
             length <<= 8;
             length |= currentOctet;
+            data = data[1..];
         }
 
         if (length > int.MaxValue)

--- a/tests/units/LDAPSessionTests.cs
+++ b/tests/units/LDAPSessionTests.cs
@@ -1,0 +1,49 @@
+using PSOpenAD.LDAP;
+using System;
+using Xunit;
+
+namespace PSOpenADTests;
+
+public static class LDAPSessionTests
+{
+    [Fact]
+    public static void ReceiveFullMessage()
+    {
+        const string MESSAGE = "MIQAAABBAgEEZYQAAAAHCgEABAAEAKCEAAAAKzCEAAAAJQQWMS4yLjg0MC4xMTM1NTYuMS40LjMxOQQLMIQAAAAFAgEABAA=";
+        byte[] messageBytes = Convert.FromBase64String(MESSAGE);
+        LDAPSession session = new();
+
+        LDAPMessage? parsedMessage = session.ReceiveData(messageBytes, out var consumed);
+
+        Assert.NotNull(parsedMessage);
+        Assert.Equal(messageBytes.Length, consumed);
+    }
+
+    [Fact]
+    public static void ReceiveFullMessageWithExtraData()
+    {
+        // Contains 4 extra bytes
+        const string MESSAGE = "MIQAAABBAgEEZYQAAAAHCgEABAAEAKCEAAAAKzCEAAAAJQQWMS4yLjg0MC4xMTM1NTYuMS40LjMxOQQLMIQAAAAFAgEABAB0ZXN0";
+        byte[] messageBytes = Convert.FromBase64String(MESSAGE);
+        LDAPSession session = new();
+
+        LDAPMessage? parsedMessage = session.ReceiveData(messageBytes, out var consumed);
+
+        Assert.NotNull(parsedMessage);
+        Assert.Equal(messageBytes.Length - 4, consumed);
+    }
+
+    [Fact]
+    public static void ReceivePartialMessageOneByteLess()
+    {
+        // Has 1 byte less than the full size
+        const string MESSAGE = "MIQAAABBAgEEZYQAAAAHCgEABAAEAKCEAAAAKzCEAAAAJQQWMS4yLjg0MC4xMTM1NTYuMS40LjMxOQQLMIQAAAAFAgEABA==";
+        byte[] messageBytes = Convert.FromBase64String(MESSAGE);
+        LDAPSession session = new();
+
+        LDAPMessage? parsedMessage = session.ReceiveData(messageBytes, out var consumed);
+
+        Assert.Null(parsedMessage);
+        Assert.Equal(0, consumed);
+    }
+}


### PR DESCRIPTION
The code for detecting whether there was enough data in the incoming buffer to parse an LDAP message was not taking the length of the length octets into the size calculation. This meant that if the total input data was between the encoded length and the encoded length - number of length octets it will still think there was enough data available causing an exception later on. E.g. consider this payload

* ASN1 tag octets - 1
* ASN1 length octets - 5
  * 1 octet to denote it's the extended form + how many subsequent octets
  * 4 octets to encode the value length
* The value length is 65
* Total length of value + ASN1 tag + ASN1 length = 71

Because the code wasn't accounting for the 4 octets that encoded the value length it considered a payload that was 67 to 70 bytes are having enough data to unpack. The code instead makes sure that the octet lengths are part of the calculation causing it to wait for more data to be received.

Fixes: https://github.com/jborean93/PSOpenAD/issues/19