### PR TITLE
Upper case the output LDAP attribute properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.0-preview5 - TBD
 
 + Fix up edge case for calculating input LDAP message lengths causing an unpack exception
++ Make the AD object properties in a `Get-*` operation return with the first character in upper case to fit the PowerShell standard
 
 ## v0.1.0-preview4 - 2022-06-15
 

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -224,7 +224,10 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
                         value = ((IList<PSObject>)value)[0];
                     }
 
-                    adPSObj.Properties.Add(new PSNoteProperty(p, value));
+                    // To make the properties more PowerShell like make sure the first char is in upper case.
+                    // PowerShell is case insensitive so users can still select it based on the lower case LDAP name.
+                    string propertyName = p[0..1].ToUpperInvariant() + p[1..];
+                    adPSObj.Properties.Add(new PSNoteProperty(propertyName, value));
                 }
 
                 outputResult = true;


### PR DESCRIPTION
Make the output note properties for each LDAP attribute start with an
upper cased letter. This makes the object fit more in line with other
.NET objects and makes things a bit nicer to read when it comes to
generating reports for these objects. Because PowerShell is case
insensitive when getting properties this will be a backwards compatible
change. Users can still select the property using the LDAP attribute
casing.

I'm not 100% convinced that this will go ahead. The changes here are to demonstrate it is relatively simple to implement and try it out.