### PR TITLE
Add better property validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 + Fix up edge case for calculating input LDAP message lengths causing an unpack exception
 + Make the AD object properties in a `Get-*` operation return with the first character in upper case to fit the PowerShell standard
++ Validate the requested `-Properties` on `Get-OpenAD*` cmdlets are valid for the object class that is being queried
+  + Invalid properties/attributes will result in a pipeling terminating error
++ Various fixes to the tab completion of `-Properties` on `Get-OpenAD*`
+  + The order will now be in alphabetical order
+  + Include attributes that are defined on auxiliary types as well as sub types
++ Ensures that the `-Properties` selected on `Get-OpenAD*` will exist in the output object
+  + If a property was requested but not set on the LDAP object, the property will now be set to `$null` rather than be missing
+  + This is a change from the Microsoft `ActiveDirectory` module which omits the properties entirely if the attribute did not have a value
 
 ## v0.1.0-preview4 - 2022-06-15
 

--- a/docs/en-US/Get-OpenADComputer.md
+++ b/docs/en-US/Get-OpenADComputer.md
@@ -203,7 +203,7 @@ When no properties are specified the following attributes are retrieved:
 
 Any attributes specified by this parameter will be added to the list above.
 Specify `*` to display all attributes that are set on the object.
-Any attributes on the object that do not have a value set will not be returned with `*`.
+Any attributes on the object that do not have a value set will not be returned with `*` unless they were also explicitly requested.
 These unset attributes must be explicitly defined for it to return on the output object.
 
 If there has been a successful connection to any LDAP server this option supports tab completion.
@@ -367,6 +367,7 @@ The `OpenADComputer` representing the object(s) found. This object will always h
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES
 Unlike `Get-ADComputer`, if an computer object cannot be found based on the `-Identity` requested this cmdlet will emit an error record.

--- a/docs/en-US/Get-OpenADGroup.md
+++ b/docs/en-US/Get-OpenADGroup.md
@@ -201,7 +201,7 @@ When no properties are specified the following attributes are retrieved:
 
 Any attributes specified by this parameter will be added to the list above.
 Specify `*` to display all attributes that are set on the object.
-Any attributes on the object that do not have a value set will not be returned with `*`.
+Any attributes on the object that do not have a value set will not be returned with `*` unless they were also explicitly requested.
 These unset attributes must be explicitly defined for it to return on the output object.
 
 If there has been a successful connection to any LDAP server this option supports tab completion.
@@ -363,6 +363,7 @@ The `OpenADGroup` representing the object(s) found. This object will always have
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES
 Unlike `Get-ADGroup`, if a group object cannot be found based on the `-Identity` requested this cmdlet will emit an error record.

--- a/docs/en-US/Get-OpenADObject.md
+++ b/docs/en-US/Get-OpenADObject.md
@@ -198,7 +198,7 @@ When no properties are specified the following attributes are retrieved:
 
 Any attributes specified by this parameter will be added to the list above.
 Specify `*` to display all attributes that are set on the object.
-Any attributes on the object that do not have a value set will not be returned with `*`.
+Any attributes on the object that do not have a value set will not be returned with `*` unless they were also explicitly requested.
 These unset attributes must be explicitly defined for it to return on the output object.
 
 If there has been a successful connection to any LDAP server this option supports tab completion.
@@ -350,6 +350,7 @@ The `OpenADObject` representing the object(s) found. This object will always hav
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES
 Unlike `Get-ADObject`, if an computer object cannot be found based on the `-Identity` requested this cmdlet will emit an error record.

--- a/docs/en-US/Get-OpenADServiceAccount.md
+++ b/docs/en-US/Get-OpenADServiceAccount.md
@@ -203,7 +203,7 @@ When no properties are specified the following attributes are retrieved:
 
 Any attributes specified by this parameter will be added to the list above.
 Specify `*` to display all attributes that are set on the object.
-Any attributes on the object that do not have a value set will not be returned with `*`.
+Any attributes on the object that do not have a value set will not be returned with `*` unless they were also explicitly requested.
 These unset attributes must be explicitly defined for it to return on the output object.
 
 If there has been a successful connection to any LDAP server this option supports tab completion.
@@ -367,6 +367,7 @@ The `OpenADServiceAccount` representing the object(s) found. This object will al
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES
 Unlike `Get-OpenADServiceAccount`, if a service account object cannot be found based on the `-Identity` requested this cmdlet will emit an error record.

--- a/docs/en-US/Get-OpenADUser.md
+++ b/docs/en-US/Get-OpenADUser.md
@@ -205,7 +205,7 @@ When no properties are specified the following attributes are retrieved:
 
 Any attributes specified by this parameter will be added to the list above.
 Specify `*` to display all attributes that are set on the object.
-Any attributes on the object that do not have a value set will not be returned with `*`.
+Any attributes on the object that do not have a value set will not be returned with `*` unless they were also explicitly requested.
 These unset attributes must be explicitly defined for it to return on the output object.
 
 If there has been a successful connection to any LDAP server this option supports tab completion.
@@ -371,6 +371,7 @@ The `OpenADUser` representing the object(s) found. This object will always have 
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES
 Unlike `Get-ADUser`, if a user object cannot be found based on the `-Identity` requested this cmdlet will emit an error record.

--- a/docs/en-US/about_OpenADComparison.md
+++ b/docs/en-US/about_OpenADComparison.md
@@ -1,0 +1,61 @@
+# Open AD Comparison With ActiveDirectory
+## about_OpenADComparison
+
+# SHORT DESCRIPTION
+While this module follows a similar setup to the Microsoft [ActiveDirectory module](https://docs.microsoft.com/en-us/powershell/module/activedirectory/?view=windowsserver2022-ps) there are some differences.
+This document will attempt to explain those differences and why they exist.
+
+# LONG DESCRIPTION
+On a technical perspective one of the key differences with this module compared to the `ActiveDirectory` module is that `PSOpenAD` uses LDAP for communication with the domain controller.
+The `ActiveDirectory` module uses a SOAP based API to communicate through the Active Directory Web Services protocol.
+In practical terms, the main difference will be the port used for communication from the client to the domain controller, LDAP runs over port `389` or `636` (TLS).
+
+# LDAPFilter vs Filter
+The `Get-OpenAD*` cmdlets do not implement the `-Filter` property that exists on the `Get-AD*` cmdlets.
+There are no plans on implementing the conversion that exists for `-Filter` as the alternative `-LDAPFilter` is available.
+The docs for [Active Directory: LDAP Syntax Filters](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx) cover a lot of the various filters that are available and how they are formatted.
+
+# Output Properties on Get Operations
+There are a few differences in the output object that the `Get-OpenAD*` cmdlets have compared to their `Get-AD*` counterparts.
+Some of the key differences are:
+
++ The requested attributes are returned in PascalCase and not the camelCase format the LDAP attributes are written as
+
+While the ActiveDirectory module does this for some return properties there are still some others that use the camelCase format.
+The PSOpenAD module will always set the return properties to be in the PascalCase format.
+
++ Properties explicitly requested but not set on the underlying object will still be present in the output object
+
+The PSOpenAD cmdlets will always return a note property for any property that was explicitly requested.
+This ensures that the output objects from a cmdlet call have a consistent set of properties rather than what was originally requested.
+Return objects can still have a dynamic set of properties as things like `-Properties *` only return properties for attributes that have a set value.
+
++ Using `-Properties *` will return less
+
+The ActiveDirectory module hard codes a set of properties to always return when requesting `-Properties *` whereas `PSOpenAD` open return the LDAP attributes that have a set value.
+To ensure a property is always present on the output object it is recommended to explicitly request that property.
+
++ Aliased properties like `lastLogonDate` are not returned
+
+Certain properties that the ActiveDirectory module return are not present in the PSOpenAD output objects.
+PSOpenAD is designed to return the LDAP attributes as they are without aliases, with some small exceptions.
+
++ Some property types are different
+
+PSOpenAD will convert the LDAP attribute values requested to .NET types that better align with what the value represents.
+Some of the types that will be used are
+
++ Interval values that represent a date will become [DateTimeOffset](https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset?view=net-6.0
+* Interval values that represent a time span will become [TimeSpan](https://docs.microsoft.com/en-us/dotnet/api/system.timespan?view=net-6.0)
+* Known enum values will be represent by an enum rather than the raw integer value
+* GUID values will become [Guid](https://docs.microsoft.com/en-us/dotnet/api/system.guid?view=net-6.0)
+* Security Identifiers will become a custom Security Identifier class that works on both Windows and non-Windows
+  * Translating these values back to an account name is only possible on Windows with `[System.Security.Principal.SecurityIdentifier]::new($obj.ObjectSid).Translate([System.Security.Principal.NTAccount])`
+* Security Descriptors will become a custom security descriptor class that works on both Windows and non-Windows
+
+This is not a complete list but should be the main ones encountered when using the PSOpenAD modules.
+
+# Tab Completion Support
+To make the cmdlets easier to use and be more discoverable, the `Get-OpenAD*` cmdlets offer tab completion for properties like `-Properties`.
+For tab completion to work there has to have been at least 1 session created by the client so the schema is cached for the completion.
+Once the schema has been cached tab completion can be used to discover the various properties that are valid for the `Get-OpenAD*` cmdlet that is being used.

--- a/docs/en-US/about_PSOpenAD.md
+++ b/docs/en-US/about_PSOpenAD.md
@@ -15,3 +15,5 @@ The [about_OpenADAuthentication](./about_OpenADAuthentication.md) docs go into f
 It also explains how to set up authentication on non-Windows hosts.
 
 The [about_OpenADSessions](./about_OpenADSessions.md) docs talk about an OpenAD session and how they are managed in this module.
+
+The [about_OpenADComparison](./about_OpenADComparison.md) docs talk about the differences between `PSOpenAD` and the Microsoft `ActiveDirectory` module provided by RSAT.

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -670,11 +670,12 @@ internal sealed class OpenADSessionFactory
         OpenADSessionOptions sessionOptions, CancellationToken cancelToken, PSCmdlet? cmdlet)
     {
         Dictionary<string, AttributeTypeDescription> attrInfo = new();
+        Dictionary<string, DITContentRuleDescription> ditInfo = new();
         Dictionary<string, ObjectClassDescription> classInfo = new();
 
         foreach (SearchResultEntry result in Operations.LdapSearchRequest(connection, subschemaSubentry,
             SearchScope.Base, 0, sessionOptions.OperationTimeout, new FilterPresent("objectClass"),
-            new string[] { "attributeTypes", "objectClasses" }, null, cancelToken, cmdlet))
+            new string[] { "attributeTypes", "dITContentRules", "objectClasses" }, null, cancelToken, cmdlet))
         {
             foreach (PartialAttribute attribute in result.Attributes)
             {
@@ -687,6 +688,11 @@ internal sealed class OpenADSessionFactory
                         AttributeTypeDescription attrTypes = new(rawValue);
                         attrInfo[attrTypes.Names[0]] = attrTypes;
                     }
+                    else if (attribute.Name == "dITContentRules")
+                    {
+                        DITContentRuleDescription ditRule = new(rawValue);
+                        ditInfo[ditRule.OID] = ditRule;
+                    }
                     else if (attribute.Name == "objectClasses")
                     {
                         ObjectClassDescription objClass = new(rawValue);
@@ -696,7 +702,7 @@ internal sealed class OpenADSessionFactory
             }
         }
 
-        return new SchemaMetadata(attrInfo, classInfo);
+        return new SchemaMetadata(attrInfo, ditInfo, classInfo);
     }
 }
 

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -42,6 +42,18 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
 
             $allObjects.Count | Should -Be $searchObjects.Count
         }
+
+        It "Fails to find entry with identity" {
+            $actual = Get-OpenADObject -Session $session -Identity invalid-id -ErrorAction SilentlyContinue -ErrorVariable err
+            $actual | Should -BeNullOrEmpty
+            $err.Count | Should -Be 1
+            $err[0].Exception.Message | Should -BeLike "Cannot find an object with identity filter: '(&(objectClass=*)(distinguishedName=invalid-id))' under: *"
+        }
+
+        It "Does not fail if no match on filter" {
+            $actual = Get-OpenADObject -Session $session -LDAPFilter '(objectClass=some-invalid-class)'
+            $actual | Should -BeNullOrEmpty
+        }
     }
 
     Context "Get-OpenADComputer" {
@@ -84,6 +96,41 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
 
             $allObjects.Count | Should -Be $searchObjects.Count
         }
+
+        It "Requests a property that is not set" {
+            $comp = Get-OpenADComputer -Session $session | Select-Object -ExpandProperty DistinguishedName -First 1
+            $actual = Get-OpenADComputer -Session $session -Identity $comp -Property operatingSystem
+            $actual.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+            $actual.PSObject.Properties.Name | Should -Contain 'Name'
+            $actual.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+            $actual.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+            $actual.PSObject.Properties.Name | Should -Contain 'DNSHostName'
+            $actual.PSObject.Properties.Name | Should -Contain 'Enabled'
+            $actual.PSObject.Properties.Name | Should -Contain 'UserPrincipalName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SamAccountName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SID'
+            $actual.DomainController | Should -Be $PSOpenADSettings.Server
+            $actual.PSObject.Properties.Name | Should -Contain 'OperatingSystem'
+        }
+
+        It "Requests a property that is not valid" {
+            {
+                Get-OpenADComputer -Session $session -Property sAMAccountName, invalid1, objectSid, invalid2 -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage "One or more properties for computer are not valid: 'invalid1', 'invalid2'"
+        }
+
+        It "Completes the properties selected" {
+            $actual = Complete 'Get-OpenADComputer -Session $session -Property '
+            $actual.Count | Should -BeGreaterThan 0
+        }
+
+        It "Completes the property with partial name" {
+            $actual = Complete 'Get-OpenADComputer -Session $session -Property operating'
+            $actual.Count | Should -BeGreaterThan 0
+            $actual | ForEach-Object {
+                $_.CompletionText -like 'operating*'
+            }
+        }
     }
 
     Context "Get-OpenADGroup" {
@@ -103,6 +150,40 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
                 $_.PSObject.Properties.Name | Should -Contain 'SamAccountName'
                 $_.PSObject.Properties.Name | Should -Contain 'SID'
                 $_.DomainController | Should -Be $PSOpenADSettings.Server
+            }
+        }
+
+        It "Requests a property that is not set" {
+            $group = Get-OpenADGroup -Session $session | Select-Object -ExpandProperty DistinguishedName -First 1
+            $actual = Get-OpenADGroup -Session $session -Identity $group -Property adminCount
+            $actual.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+            $actual.PSObject.Properties.Name | Should -Contain 'Name'
+            $actual.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+            $actual.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+            $actual.PSObject.Properties.Name | Should -Contain 'GroupCategory'
+            $actual.PSObject.Properties.Name | Should -Contain 'GroupScope'
+            $actual.PSObject.Properties.Name | Should -Contain 'SamAccountName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SID'
+            $actual.DomainController | Should -Be $PSOpenADSettings.Server
+            $actual.PSObject.Properties.Name | Should -Contain 'AdminCount'
+        }
+
+        It "Requests a property that is not valid" {
+            {
+                Get-OpenADGroup -Session $session -Property sAMAccountName, invalid1, objectSid, invalid2 -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage "One or more properties for group are not valid: 'invalid1', 'invalid2'"
+        }
+
+        It "Completes the properties selected" {
+            $actual = Complete 'Get-OpenADGroup -Session $session -Property '
+            $actual.Count | Should -BeGreaterThan 0
+        }
+
+        It "Completes the property with partial name" {
+            $actual = Complete 'Get-OpenADGroup -Session $session -Property msDS'
+            $actual.Count | Should -BeGreaterThan 0
+            $actual | ForEach-Object {
+                $_.CompletionText -like 'msDS*'
             }
         }
     }
@@ -130,6 +211,43 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $searchObjects = Get-OpenADGroup -Session $session -SearchBase $session.DefaultNamingContext
 
             $allObjects.Count | Should -Be $searchObjects.Count
+        }
+
+        It "Requests a property that is not set" {
+            $user = Get-OpenADUser -Session $session | Select-Object -ExpandProperty DistinguishedName -First 1
+            $actual = Get-OpenADUser -Session $session -Identity $user -Property title
+            $actual.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+            $actual.PSObject.Properties.Name | Should -Contain 'Name'
+            $actual.PSObject.Properties.Name | Should -Contain 'ObjectClass'
+            $actual.PSObject.Properties.Name | Should -Contain 'ObjectGuid'
+            $actual.PSObject.Properties.Name | Should -Contain 'GivenName'
+            $actual.PSObject.Properties.Name | Should -Contain 'Surname'
+            $actual.PSObject.Properties.Name | Should -Contain 'Enabled'
+            $actual.PSObject.Properties.Name | Should -Contain 'UserPrincipalName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SamAccountName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SID'
+            $actual.DomainController | Should -Be $PSOpenADSettings.Server
+            $actual.PSObject.Properties.Name | Should -Contain 'Title'
+            $actual.Title | Should -BeNullOrEmpty
+        }
+
+        It "Requests a property that is not valid" {
+            {
+                Get-OpenADUser -Session $session -Property sAMAccountName, invalid1, objectSid, invalid2 -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage "One or more properties for person are not valid: 'invalid1', 'invalid2'"
+        }
+
+        It "Completes the properties selected" {
+            $actual = Complete 'Get-OpenADUser -Session $session -Property '
+            $actual.Count | Should -BeGreaterThan 0
+        }
+
+        It "Completes the property with partial name" {
+            $actual = Complete 'Get-OpenADUser -Session $session -Property last'
+            $actual.Count | Should -BeGreaterThan 0
+            $actual | ForEach-Object {
+                $_.CompletionText -like 'last*'
+            }
         }
     }
 }

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -55,3 +55,18 @@ if (-not $global:PSOpenADSettings) {
     }
 
 }
+
+Function Global:Complete {
+    [OutputType([System.Management.Automation.CompletionResult])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]
+        $Expression
+    )
+
+    [System.Management.Automation.CommandCompletion]::CompleteInput(
+        $Expression,
+        $Expression.Length,
+        $null).CompletionMatches
+}


### PR DESCRIPTION
The Get-OpenAD* cmdlets will attempt to validate that the requested
properties are valid for the object type being requested. It does this
by consulting the list of attributes defined for the objectClass being
queries as well as any auxiliary class that is associated with it.
Attempting to use an invalid property will cause an error.

Properties that are explicitly requested but are not set will still be
present on the request object but with a `$null` value.