### PR TITLE
Handle connection socket reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 + Ensures that the `-Properties` selected on `Get-OpenAD*` will exist in the output object
   + If a property was requested but not set on the LDAP object, the property will now be set to `$null` rather than be missing
   + This is a change from the Microsoft `ActiveDirectory` module which omits the properties entirely if the attribute did not have a value
++ Ensure connections that have timed out are not reused causing a deadlock
 
 ## v0.1.0-preview4 - 2022-06-15
 

--- a/src/Commands/OpenADSession.cs
+++ b/src/Commands/OpenADSession.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Management.Automation;
 using System.Threading;
 
@@ -13,10 +12,9 @@ public class GetOpenADSession : PSCmdlet
 {
     protected override void EndProcessing()
     {
-        foreach (OpenADSession session in GlobalState.Sessions)
-        {
-            WriteObject(session);
-        }
+        // Ensure the sessions are their own collection to avoid something further down the line mutating the same
+        // list during an enumeration, e.g. 'Get-OpenADSession | Remove-OpenADSession'
+        WriteObject(GlobalState.Sessions.ToArray(), true);
     }
 }
 
@@ -118,9 +116,5 @@ public class RemoveOpenADSession : PSCmdlet
             WriteVerbose($"Closing connection to {s.Uri}");
             s.Close();
         }
-
-        GlobalState.Sessions = GlobalState.Sessions
-            .Where(x => !Session.Any(y => y.Id == x.Id))
-            .ToList();
     }
 }

--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -225,11 +225,6 @@ internal class OpenADConnection : IDisposable
                     break;
                 }
             }
-            catch (IOException e) when (e.InnerException is SocketException)
-            {
-                // Typically due to the server closing the socket before we had a chance to cancel it ourselves.
-                break;
-            }
             catch (Exception e)
             {
                 // Unknown failure - propagate back to the task waiters.
@@ -242,6 +237,8 @@ internal class OpenADConnection : IDisposable
                 break;
         }
 
+        Session.Close();
+        _closed = true;
         await writer.CompleteAsync();
     }
 


### PR DESCRIPTION
Will properly mark a connection as closed if a socket reset was received
by the server. It should also better handle trying to re-use a
connection that has been closed instead of hanging forever.

Fixes: https://github.com/jborean93/PSOpenAD/issues/43