### PR TITLE
Filter out contacts with Get-OpenADUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   + If a property was requested but not set on the LDAP object, the property will now be set to `$null` rather than be missing
   + This is a change from the Microsoft `ActiveDirectory` module which omits the properties entirely if the attribute did not have a value
 + Ensure connections that have timed out are not reused causing a deadlock
++ Ensure `Get-OpenADUser` also filtered by `(objectClass=user)` to avoid pulling in contacts
 
 ## v0.1.0-preview4 - 2022-06-15
 

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -329,7 +329,10 @@ public class GetOpenADUser : GetOpenADOperation<ADPrincipalIdentity>
     internal override (string, bool)[] DefaultProperties => OpenADUser.DEFAULT_PROPERTIES;
 
     internal override LDAPFilter FilteredClass
-        => new FilterEquality("objectCategory", LDAP.LDAPFilter.EncodeSimpleFilterValue("person"));
+        => new FilterAnd(new LDAPFilter[] {
+            new FilterEquality("objectCategory", LDAP.LDAPFilter.EncodeSimpleFilterValue("person")),
+            new FilterEquality("objectClass", LDAP.LDAPFilter.EncodeSimpleFilterValue("user"))
+        });
 
     internal override OpenADObject CreateADObject(Dictionary<string, (PSObject[], bool)> attributes)
         => new OpenADUser(attributes);

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -249,5 +249,12 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
                 $_.CompletionText -like 'last*'
             }
         }
+
+        It "Ignores contacts in the default filter" {
+            $actual = Get-OpenADUser -Identity MyTestContact -ErrorAction SilentlyContinue -ErrorVariable err
+            $actual | Should -BeNullOrEmpty
+            $err.Count | Should -Be 1
+            $err[0].Exception.Message | Should -BeLike "Cannot find an object with identity filter: '(&(&(objectCategory=person)(objectClass=user))(sAMAccountName=MyTestContact))' under: *"
+        }
     }
 }

--- a/tools/setup-samba.sh
+++ b/tools/setup-samba.sh
@@ -49,4 +49,8 @@ samba-tool domain provision \
 
 cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 
+# FUTURE: Move this to the test suite once New-OpenADObject has been implented
+samba-tool contact add \
+    MyTestContact
+
 samba --debug-stderr --foreground --no-process-group


### PR DESCRIPTION
Ensure contacts and other unknown types are filtered out of the
Get-OpenADUser cmdlet by adding (objectClass=user) to the default LDAP
filter that is run.

Fixes https://github.com/jborean93/PSOpenAD/issues/44