### PR TITLE
Fix get operation without property metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for PSOpenAD
 
+## v0.1.0 - TBD
+
++ Fix up `Get-OpenAD*` calls where there is no valid metadata to calculate the valid properties.
++ Minor tweaks to error messages when using an un-authenticated bind.
+
 ## v0.1.0-preview5 - 2022-06-27
 
 + Fix up edge case for calculating input LDAP message lengths causing an unpack exception

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -95,7 +95,7 @@
 
         PSData = @{
 
-            Prerelease   = 'preview5'
+            # Prerelease   = 'preview1'
 
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags         = @(

--- a/src/Schema.cs
+++ b/src/Schema.cs
@@ -199,9 +199,9 @@ internal sealed class SchemaMetadata
     public void RegisterTransformer(string attribute, DefaultOverrider.CustomTransform transformer)
         => DefaultOverrider.Overrides[attribute] = transformer;
 
-    public ObjectClass GetClassInformation(string name)
+    public ObjectClass? GetClassInformation(string name)
     {
-        return _classInformation[name];
+        return _classInformation.GetValueOrDefault(name);
     }
 
     public (PSObject[], bool) TransformAttributeValue(string attribute, IList<byte[]> value, PSCmdlet? cmdlet)

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -262,7 +262,7 @@ internal sealed class OpenADSessionFactory
             };
             foreach (SearchResultEntry searchRes in Operations.LdapSearchRequest(connection, "", SearchScope.Base,
                 0, sessionOptions.OperationTimeout, new FilterPresent("objectClass"),
-                baseAttributes, null, cancelToken, cmdlet))
+                baseAttributes, null, cancelToken, cmdlet, true))
             {
                 foreach (PartialAttribute attribute in searchRes.Attributes)
                 {
@@ -674,7 +674,7 @@ internal sealed class OpenADSessionFactory
 
         foreach (SearchResultEntry result in Operations.LdapSearchRequest(connection, subschemaSubentry,
             SearchScope.Base, 0, sessionOptions.OperationTimeout, new FilterPresent("objectClass"),
-            new string[] { "attributeTypes", "dITContentRules", "objectClasses" }, null, cancelToken, cmdlet))
+            new string[] { "attributeTypes", "dITContentRules", "objectClasses" }, null, cancelToken, cmdlet, true))
         {
             foreach (PartialAttribute attribute in result.Attributes)
             {


### PR DESCRIPTION
Fix get operations where the session does not have any schema metadata
to check the properties with. This is mostly a rare scenario, like
unauthenticated binds, where no schema metadata could be retrieved as
the unauthenticated bind does not have permission to do so. This fact
will be seen in the search response and is preferable to a "not a valid
attribute message" that was previously shown.

Also bumps the version to 0.1.0 actual as I feel it is ready.

I tried adding some tests for this scenario but unfortunately Samba does not allow unauthenticated binds unlike AD so they won't be tested here.