### PR TITLE
Restart case insensitive property matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSOpenAD
 
+## v0.1.1 - TBD
+
++ Fix up case insensitive matching for requested LDAP attributes/properties.
+
 ## v0.1.0 - 2022-07-09
 
 + Fix up `Get-OpenAD*` calls where there is no valid metadata to calculate the valid properties.

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'bin/netcoreapp3.1/PSOpenAD.dll'
 
     # Version number of this module.
-    ModuleVersion          = '0.1.0'
+    ModuleVersion          = '0.1.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -190,7 +190,7 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
             ObjectClass? objectClass = Session.SchemaMetadata.GetClassInformation(className);
             if (objectClass is null)
             {
-                validProperties = explicitProperties.ToHashSet();
+                validProperties = explicitProperties.ToHashSet(comparer);
             }
             else
             {
@@ -230,7 +230,6 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
                 ThrowTerminatingError(rec);
                 return;
             }
-
 
             string searchBase = SearchBase ?? Session.DefaultNamingContext;
             bool outputResult = false;

--- a/src/Schema.cs
+++ b/src/Schema.cs
@@ -111,7 +111,7 @@ internal sealed class ObjectClass
         {
             _validAttributes.UnionWith(subType.ValidAttributes);
         }
-        _validAttributes = _validAttributes.OrderBy(p => p).ToHashSet();
+        _validAttributes = _validAttributes.OrderBy(p => p).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         return _validAttributes;
     }

--- a/tests/OpenADObject.Tests.ps1
+++ b/tests/OpenADObject.Tests.ps1
@@ -256,5 +256,12 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $err.Count | Should -Be 1
             $err[0].Exception.Message | Should -BeLike "Cannot find an object with identity filter: '(&(&(objectCategory=person)(objectClass=user))(sAMAccountName=MyTestContact))' under: *"
         }
+
+        It "Requests property with different casing" {
+            $user = Get-OpenADUser -Session $session | Select-Object -ExpandProperty DistinguishedName -First 1
+            $actual = Get-OpenADUser -Session $session -Identity $user -Property LASTLOGOFF
+            $actual.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
+            $actual.PSObject.Properties.Name | Should -Contain 'LastLogoff'
+        }
     }
 }


### PR DESCRIPTION
Ensure requested properties are checked in a case insensitive fashion.
This was the original behaviour but a bad change made the check case
sensitive.

Fixes: https://github.com/jborean93/PSOpenAD/issues/51