### PR TITLE
Tidy up Get-OpenADGroupMember

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "type": "shell",
             "args": [
                 "-Command",
-                "Import-Module ${workspaceFolder}/output/PSOpenAD; Import-Module platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
+                "Import-Module ${workspaceFolder}/output/PSOpenAD; Import-Module ${workspaceFolder}/tools/Modules/platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
             ],
             "problemMatcher": [],
             "dependsOn": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSOpenAD
 
+## v0.2.0 - TBD
+
++ Added `Get-OpenADGroupMember` that returns members of a group - thanks @theaquamarine
+
 ## v0.1.1 - 2022-07-28
 
 + Fix up case insensitive matching for requested LDAP attributes/properties.

--- a/docs/en-US/Get-OpenADComputer.md
+++ b/docs/en-US/Get-OpenADComputer.md
@@ -367,6 +367,7 @@ The `OpenADComputer` representing the object(s) found. This object will always h
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADGroup.md
+++ b/docs/en-US/Get-OpenADGroup.md
@@ -363,6 +363,7 @@ The `OpenADGroup` representing the object(s) found. This object will always have
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADGroupMember.md
+++ b/docs/en-US/Get-OpenADGroupMember.md
@@ -361,6 +361,8 @@ The `OpenADPrincipal` representing the member objects. This object will always h
 
 + `DomainController`: This is set to the domain controller that processed the request
 
++ `QueriedGroup`: The distinguished name of the group this object is a member of
+
 Any explicit attributes requested through `-Property` are also present on the object.
 
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.

--- a/docs/en-US/Get-OpenADGroupMember.md
+++ b/docs/en-US/Get-OpenADGroupMember.md
@@ -1,7 +1,7 @@
 ---
 external help file: PSOpenAD.dll-Help.xml
 Module Name: PSOpenAD
-online version:
+online version: https://www.github.com/jborean93/PSOpenAD/blob/main/docs/en-US/Get-OpenADGroupMember.md
 schema: 2.0.0
 ---
 
@@ -14,19 +14,43 @@ Gets the members of an Active Directory group.
 
 ### ServerIdentity (Default)
 ```
-Get-OpenADGroupMember [-Server <String>] [-AuthType <AuthenticationMethod>]
+Get-OpenADGroupMember [-Recursive] [-Server <String>] [-AuthType <AuthenticationMethod>]
  [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>]
  [-Identity] <ADPrincipalIdentity> [-Property <String[]>] [<CommonParameters>]
 ```
 
 ### SessionIdentity
 ```
-Get-OpenADGroupMember -Session <OpenADSession> [-Identity] <ADPrincipalIdentity> [-Property <String[]>]
- [<CommonParameters>]
+Get-OpenADGroupMember [-Recursive] -Session <OpenADSession> [-Identity] <ADPrincipalIdentity>
+ [-Property <String[]>] [<CommonParameters>]
+```
+
+### SessionLDAPFilter
+```
+Get-OpenADGroupMember [-Recursive] -Session <OpenADSession> [-LDAPFilter <String>] [-SearchBase <String>]
+ [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
+```
+
+### ServerLDAPFilter
+```
+Get-OpenADGroupMember [-Recursive] [-Server <String>] [-AuthType <AuthenticationMethod>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [-LDAPFilter <String>]
+ [-SearchBase <String>] [-SearchScope <SearchScope>] [-Property <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Get-OpenADGroupMember` cmdlet returns the member objects of a group specified by `-Identity`.
+The `Get-OpenADGroupMember` cmdlet returns the member objects of a group specified by `-Identity` or the groups found by `-LDAPFilter`.
+
+The `Identity` parameter specifies the active directory group to get the members for.
+You can specify the identity of the group with the distinguished name, GUID, User Principal Name (UPN), Security Account Manager (SAM) name, or security identifier.
+The group can also be specified by passing in a group object through the pipeline.
+
+The `LDAPFilter` parameter can be used to specify multiple groups to get the membership of.
+Keep in mind the output does not distinguish what groups the members were off if multiple groups were found.
+Using `Identity` or piping in 1 group object will ensure only those members are outputted.
+
+If the `Recursive` parameter is specified, the cmdlet gets all users of the group as well as users of each group member.
+Like `Get-ADGroupMember`, it will not return members of the groups which are groups themselves, only the other principal classes.
 
 The cmdlet communicates with the LDAP server in one of three ways:
 
@@ -72,7 +96,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: AuthenticationMethod
-Parameter Sets: ServerIdentity
+Parameter Sets: ServerIdentity, ServerLDAPFilter
 Aliases:
 Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos, Certificate
 
@@ -89,7 +113,7 @@ This is used when the cmdlet creates a new connection to the `-Server` specified
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServerIdentity
+Parameter Sets: ServerIdentity, ServerLDAPFilter
 Aliases:
 
 Required: False
@@ -114,16 +138,33 @@ Specifies the Active Directory group to list the members of using one of the fol
 
 The cmdlet writes an error if no group is found based on the identity specified.
 In addition the identity is filtered by the LDAP filter `(objectCategory=group)` to restrict only group objects from being searched.
+The `-LDAPFilter` parameter can be used instead to query for multiple objects.
 
 ```yaml
 Type: ADPrincipalIdentity
-Parameter Sets: (All)
+Parameter Sets: ServerIdentity, SessionIdentity
 Aliases:
 
 Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -LDAPFilter
+Used instead of `-Identity` to specify an LDAP query used to filter group objects.
+The filter specified here will be used with an `AND` condition to `(objectCategory=group)`.
+
+```yaml
+Type: String
+Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -150,14 +191,70 @@ Any attributes on the object that do not have a value set will not be returned w
 These unset attributes must be explicitly defined for it to return on the output object.
 
 If there has been a successful connection to any LDAP server this option supports tab completion.
-The possible properties shown in the tab completion are based on the schema returned by the server for the `top` object class.
+The possible properties shown in the tab completion are based on the schema returned by the server for the `person` object class.
 If no connection has been created by the client then there is no tab completion available.
-
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
 Aliases: Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Recursive
+Specifies that all members in the hierarchy of a group that do no contain child objects.
+Essentially this will return all principals of the group, including principals of each group member, but not the groups themselves.
+
+When requested, the membership of the group is queried with the filter `(&(!objectCategory=group)(memberOf:1.2.840.113556.1.4.1941=Group DN))`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SearchBase
+The base Active Directory path to search the object for.
+This defaults to the `defaultNamingContext` of the session connection which is typically the root of the domain.
+Combine this with `-SearchScope` to limit searches to a smaller subset of the domain.
+
+```yaml
+Type: String
+Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SearchScope
+Specifies the scope of an Active Directory search.
+This can be set to
+
++ `Base` - Only searches the object at the `-SearchBase` path specified
+
++ `OneLevel` - Searches the immediate children of `-SearchBase`
+
++ `Subtree` (default) - Searches the children of `-SearchBase` and subsquent children of them
+
+```yaml
+Type: SearchScope
+Parameter Sets: SessionLDAPFilter, ServerLDAPFilter
+Aliases:
 
 Required: False
 Position: Named
@@ -178,7 +275,7 @@ This option is mutually exclusive with `-Session`.
 
 ```yaml
 Type: String
-Parameter Sets: ServerIdentity
+Parameter Sets: ServerIdentity, ServerLDAPFilter
 Aliases:
 
 Required: False
@@ -196,7 +293,7 @@ This option is mutually exclusive with `-Server`.
 
 ```yaml
 Type: OpenADSession
-Parameter Sets: SessionIdentity
+Parameter Sets: SessionIdentity, SessionLDAPFilter
 Aliases:
 
 Required: True
@@ -212,7 +309,7 @@ These options can be generated with `New-OpenADSessionOption`.
 
 ```yaml
 Type: OpenADSessionOptions
-Parameter Sets: ServerIdentity
+Parameter Sets: ServerIdentity, ServerLDAPFilter
 Aliases:
 
 Required: False
@@ -227,7 +324,7 @@ Use `StartTLS` when creating a new session with `-Server`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerIdentity
+Parameter Sets: ServerIdentity, ServerLDAPFilter
 Aliases:
 
 Required: False
@@ -265,8 +362,14 @@ The `OpenADPrincipal` representing the member objects. This object will always h
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES
+Unlike `Get-ADGroupMember`, if a group object cannot be found based on the `-Identity` requested this cmdlet will emit an error record.
+Setting `-ErrorAction Stop` on the call can turn this error into an exception and have it act like `Get-ADGroupMember`.
 
 ## RELATED LINKS
+
+[Active Directory: LDAP Syntax Filters](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx)
+[LDAP Filters](https://ldap.com/ldap-filters/)

--- a/docs/en-US/Get-OpenADObject.md
+++ b/docs/en-US/Get-OpenADObject.md
@@ -350,6 +350,7 @@ The `OpenADObject` representing the object(s) found. This object will always hav
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADServiceAccount.md
+++ b/docs/en-US/Get-OpenADServiceAccount.md
@@ -367,6 +367,7 @@ The `OpenADServiceAccount` representing the object(s) found. This object will al
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES

--- a/docs/en-US/Get-OpenADUser.md
+++ b/docs/en-US/Get-OpenADUser.md
@@ -371,6 +371,7 @@ The `OpenADUser` representing the object(s) found. This object will always have 
 + `DomainController`: This is set to the domain controller that processed the request
 
 Any explicit attributes requested through `-Property` are also present on the object.
+
 If an LDAP attribute on the underlying object did not have a value set but was explicitly requested then the property will be set to `$null`.
 
 ## NOTES

--- a/docs/en-US/PSOpenAD.md
+++ b/docs/en-US/PSOpenAD.md
@@ -20,6 +20,9 @@ Get one or more Active Directory computers.
 ### [Get-OpenADGroup](Get-OpenADGroup.md)
 Gets one or more Active Directory groups.
 
+### [Get-OpenADGroupMember](Get-OpenADGroupMember.md)
+Gets the members of an Active Directory group.
+
 ### [Get-OpenADObject](Get-OpenADObject.md)
 Gets one or more Active Directory objects.
 

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'bin/netcoreapp3.1/PSOpenAD.dll'
 
     # Version number of this module.
-    ModuleVersion          = '0.1.1'
+    ModuleVersion          = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Commands/OpenADGroupMember.cs
+++ b/src/Commands/OpenADGroupMember.cs
@@ -1,11 +1,8 @@
 using PSOpenAD.LDAP;
 using PSOpenAD.Security;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Language;
-using System.Reflection;
 using System.Threading;
 
 namespace PSOpenAD.Commands;
@@ -15,247 +12,69 @@ namespace PSOpenAD.Commands;
     DefaultParameterSetName = "ServerIdentity"
 )]
 [OutputType(typeof(OpenADPrincipal))]
-public class GetOpenADGroupMember : PSCmdlet
+public class GetOpenADGroupMember : GetOpenADOperation<ADPrincipalIdentity>
 {
-    internal bool _includeDeleted = false;
-
-    private CancellationTokenSource? CurrentCancelToken { get; set; }
-
-    internal (string, bool)[] DefaultProperties => OpenADPrincipal.DEFAULT_PROPERTIES;
-
-    #region Connection Parameters
-
-    [Parameter(
-        Mandatory = true,
-        ParameterSetName = "SessionIdentity"
-    )]
-    public OpenADSession? Session { get; set; }
-
-    [Parameter(ParameterSetName = "ServerIdentity")]
-    [ArgumentCompleter(typeof(ServerCompleter))]
-    public string Server { get; set; } = "";
-
-    [Parameter(ParameterSetName = "ServerIdentity")]
-    public AuthenticationMethod AuthType { get; set; } = AuthenticationMethod.Default;
-
-    [Parameter(ParameterSetName = "ServerIdentity")]
-    public OpenADSessionOptions SessionOption { get; set; } = new OpenADSessionOptions();
-
-    [Parameter(ParameterSetName = "ServerIdentity")]
-    public SwitchParameter StartTLS { get; set; }
-
-    [Parameter(ParameterSetName = "ServerIdentity")]
-    [Credential()]
-    public PSCredential? Credential { get; set; }
-
-    #endregion
-
-    #region Identity Parameters
-
-    [Parameter(
-        Mandatory = true,
-        Position = 0,
-        ValueFromPipeline = true,
-        ValueFromPipelineByPropertyName = true
-    )]
-    [ValidateNotNullOrEmpty]
-    public ADPrincipalIdentity? Identity { get; set; }
-
-    #endregion
-
-    #region Common Parameters
-
-    [Parameter()]
-    [Alias("Properties")]
-    [ValidateNotNullOrEmpty]
-    [ArgumentCompleter(typeof(PropertyCompleter))]
-    public string[]? Property { get; set; }
-
     [Parameter()]
     public SwitchParameter Recursive { get; set; }
 
-    #endregion
+    internal override (string, bool)[] DefaultProperties => OpenADPrincipal.DEFAULT_PROPERTIES;
 
-    protected override void ProcessRecord()
+    internal override LDAPFilter FilteredClass
+        => new FilterEquality("objectCategory", LDAP.LDAPFilter.EncodeSimpleFilterValue("group"));
+
+    internal override OpenADObject CreateADObject(Dictionary<string, (PSObject[], bool)> attributes)
+        => new OpenADPrincipal(attributes);
+
+    internal override IEnumerable<SearchResultEntry> SearchRequest(OpenADSession session, string searchBase,
+        LDAP.LDAPFilter filter, string[] attributes, IList<LDAPControl>? serverControls, CancellationToken cancelToken)
     {
-        if (Identity == null) {
-            return;
-        }
-
-        LDAPFilter finalFilter;
-        finalFilter = new FilterAnd(new[] {
-            new FilterEquality("objectCategory", LDAP.LDAPFilter.EncodeSimpleFilterValue("group")),
-            Identity.LDAPFilter
-        });
-
-        List<LDAPControl>? serverControls = null;
-        if (_includeDeleted)
+        foreach (SearchResultEntry group in Operations.LdapSearchRequest(session.Connection, searchBase,
+            SearchScope, 1, session.OperationTimeout, filter, new[] { "objectSid" }, serverControls, cancelToken, this,
+            false))
         {
-            serverControls = new();
-            serverControls.Add(new ShowDeleted(false));
-            serverControls.Add(new ShowDeactivatedLink(false));
-        }
-
-        using (CurrentCancelToken = new CancellationTokenSource())
-        {
-            if (Session == null)
+            // use memberOf rather than member to make recursive search easier & avoid paging
+            LDAPFilter memberOfFilter;
+            if (Recursive)
             {
-                Session = OpenADSessionFactory.CreateOrUseDefault(Server, Credential, AuthType, StartTLS,
-                    SessionOption, CurrentCancelToken.Token, this);
-            }
-
-            if (Session == null)
-                return; // Failed to create session - error records have already been written.
-
-            StringComparer comparer = StringComparer.OrdinalIgnoreCase;
-            string className = PropertyCompleter.GetClassNameForCommand(MyInvocation.MyCommand.Name);
-            HashSet<string> requestedProperties = DefaultProperties.Select(p => p.Item1).ToHashSet(comparer);
-            string[] explicitProperties = Property ?? Array.Empty<string>();
-            bool showAll = false;
-
-            // We can only validate modules if there was metadata. Metadata may not be present on all systems and
-            // when unauthenticated authentication was used.
-            HashSet<string> validProperties;
-            ObjectClass? objectClass = Session.SchemaMetadata.GetClassInformation(className);
-            if (objectClass is null)
-            {
-                validProperties = explicitProperties.ToHashSet(comparer);
-            }
-            else
-            {
-                validProperties = objectClass.ValidAttributes;
-            }
-
-            HashSet<string> invalidProperties = new();
-
-            foreach (string prop in explicitProperties)
-            {
-                if (prop == "*")
-                {
-                    showAll = true;
-                    requestedProperties.Add(prop);
-                    continue;
-                }
-
-                if (validProperties.Contains(prop))
-                {
-                    requestedProperties.Add(prop);
-                }
-                else
-                {
-                    invalidProperties.Add(prop);
-                }
-            }
-
-            if (invalidProperties.Count > 0)
-            {
-                string sortedProps = string.Join("', '", invalidProperties.OrderBy(p => p).ToArray());
-                ErrorRecord rec = new(
-                    new ArgumentException($"One or more properties for '{className}' class are not valid: '{sortedProps}'"),
-                    "InvalidPropertySet",
-                    ErrorCategory.InvalidArgument,
-                    null);
-
-                ThrowTerminatingError(rec);
-                return;
-            }
-
-            string searchBase = Session.DefaultNamingContext;
-            bool outputResult = false;
-
-            SearchResultEntry group = Operations.LdapSearchRequest(Session.Connection, searchBase,
-                SearchScope.Subtree, 1, Session.OperationTimeout, finalFilter, requestedProperties.ToArray(), serverControls,
-                CurrentCancelToken.Token, this, false).FirstOrDefault(); //SingleOrDefault()?
-            if (group != null)
-            {
-                outputResult = true;
-
-                // use memberOf rather than member to make recursive search easier & avoid paging
-                LDAPFilter memberOfFilter;
-                if (Recursive) {
-                    // Manually recursing into groups would also work, not sure where perf sweet spot is.
-                    // Exclude groups to match Get-ADGroupMembership results. Including only objectClass=user works too.
-                    memberOfFilter = new FilterAnd( new LDAPFilter[] {
+                // Manually recursing into groups would also work, not sure where perf sweet spot is.
+                // Exclude groups to match Get-ADGroupMembership results. Including only objectClass=user works too.
+                memberOfFilter = new FilterAnd(new LDAPFilter[] {
                         new FilterNot(
                             new FilterEquality("objectCategory", LDAP.LDAPFilter.EncodeSimpleFilterValue("group"))
                         ),
-                        new FilterExtensibleMatch("1.2.840.113556.1.4.1941", "memberOf", LDAP.LDAPFilter.EncodeSimpleFilterValue(group.ObjectName), false)
+                        new FilterExtensibleMatch("1.2.840.113556.1.4.1941", "memberOf",
+                            LDAP.LDAPFilter.EncodeSimpleFilterValue(group.ObjectName), false)
                     });
-                } else {
-                    memberOfFilter = new FilterEquality("memberOf", LDAP.LDAPFilter.EncodeSimpleFilterValue(group.ObjectName));
-                }
+            }
+            else
+            {
+                memberOfFilter = new FilterEquality("memberOf",
+                    LDAP.LDAPFilter.EncodeSimpleFilterValue(group.ObjectName));
+            }
 
-                // get group's rid and include (primaryGroupID=$RID) for primary groups. Only on user so no recursion.
-                SecurityIdentifier sid = new SecurityIdentifier(
-                    Array.Find(group.Attributes, x => x.Name.Equals("objectSid")).Values[0]
-                    );
+            // get group's rid and include (primaryGroupID=$RID) for primary groups. Only on user so no recursion.
+            // objectSid is most likely going to be there but it's optionally added to satisfy dotnet's null checks.
+            SecurityIdentifier? sid = group.Attributes
+                .Where(a => a.Name == "objectSid")
+                .Select(a => new SecurityIdentifier(a.Values[0]))
+                .FirstOrDefault();
+
+            if (sid != null)
+            {
                 string rid = sid.ToString().Split("-").Last();
 
-                memberOfFilter = new FilterOr( new LDAPFilter[] {memberOfFilter,
-                    new FilterEquality("primaryGroupID", LDAPFilter.EncodeSimpleFilterValue(rid))
-                    } );
-
-                foreach (SearchResultEntry result in Operations.LdapSearchRequest(Session.Connection, searchBase,
-                    SearchScope.Subtree, 0, Session.OperationTimeout, memberOfFilter, requestedProperties.ToArray(), serverControls,
-                    CurrentCancelToken.Token, this, false))
-                {
-                    Dictionary<string, (PSObject[], bool)> props = new();
-                    foreach (PartialAttribute attribute in result.Attributes)
-                    {
-                        props[attribute.Name] = Session.SchemaMetadata.TransformAttributeValue(attribute.Name,
-                            attribute.Values, this);
-                    }
-
-                    OpenADPrincipal adObj = new(props);
-
-                    // This adds a note property for each explicitly requested property, excluding the ones the object
-                    // naturally exposes. Also adds the DomainController property to denote what DC the response came from.
-                    PSObject adPSObj = PSObject.AsPSObject(adObj);
-                    adPSObj.Properties.Add(new PSNoteProperty("DomainController", Session.DomainController));
-
-                    List<string> orderedProps = props.Keys
-                        .Union(requestedProperties, comparer)
-                        .Where(v =>
-                            v != "*" &&
-                            (showAll || explicitProperties.Contains(v, comparer)) &&
-                            !DefaultProperties.Contains((v, true)))
-                        .OrderBy(v => v)
-                        .ToList();
-
-                    foreach (string p in orderedProps)
-                    {
-                        object? value = null;
-                        if (props.ContainsKey(p))
-                        {
-                            (value, bool isSingleValue) = props[p];
-                            if (isSingleValue)
-                            {
-                                value = ((IList<PSObject>)value)[0];
-                            }
-                        }
-
-                        // To make the properties more PowerShell like make sure the first char is in upper case.
-                        // PowerShell is case insensitive so users can still select it based on the lower case LDAP name.
-                        string propertyName = p[0..1].ToUpperInvariant() + p[1..];
-                        adPSObj.Properties.Add(new PSNoteProperty(propertyName, value));
-                    }
-
-                    WriteObject(adObj);
-                }
+                memberOfFilter = new FilterOr(new[] {
+                    memberOfFilter,
+                    new FilterEquality("primaryGroupID", LDAP.LDAPFilter.EncodeSimpleFilterValue(rid))
+                });
             }
 
-            if (!outputResult)
+            foreach (SearchResultEntry result in Operations.LdapSearchRequest(session.Connection, searchBase,
+                SearchScope, 0, session.OperationTimeout, memberOfFilter, attributes, serverControls, cancelToken,
+                this, false))
             {
-                string msg = $"Cannot find an object with identity filter: '{finalFilter}' under: '{searchBase}'";
-                ErrorRecord rec = new(new ItemNotFoundException(msg), "IdentityNotFound",
-                    ErrorCategory.ObjectNotFound, finalFilter.ToString());
-                WriteError(rec);
+                yield return result;
             }
         }
-    }
-
-    protected override void StopProcessing()
-    {
-        CurrentCancelToken?.Cancel();
     }
 }

--- a/src/Commands/OpenADObject.cs
+++ b/src/Commands/OpenADObject.cs
@@ -281,6 +281,7 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
                     adPSObj.Properties.Add(new PSNoteProperty(propertyName, value));
                 }
 
+                ProcessOutputObject(adPSObj);
                 outputResult = true;
                 WriteObject(adObj);
             }
@@ -306,6 +307,8 @@ public abstract class GetOpenADOperation<T> : PSCmdlet
         return Operations.LdapSearchRequest(session.Connection, searchBase, SearchScope, 0, session.OperationTimeout,
             filter, attributes, serverControls, cancelToken, this, false);
     }
+
+    internal virtual void ProcessOutputObject(PSObject obj) { }
 }
 
 [Cmdlet(

--- a/src/Completer.cs
+++ b/src/Completer.cs
@@ -66,6 +66,7 @@ internal class PropertyCompleter : IArgumentCompleter
         "Get-OpenADComputer" => "computer",
         "Get-OpenADUser" => "person",
         "Get-OpenADGroup" => "group",
+        "Get-OpenADGroupMember" => "person",
         "Get-OpenADServiceAccount" => "msDS-GroupManagedServiceAccount",
         _ => "top",
     };

--- a/tests/Get-OpenADGroupMember.Tests.ps1
+++ b/tests/Get-OpenADGroupMember.Tests.ps1
@@ -20,6 +20,7 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
 
             $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'QueriedGroup'
                 $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
                 $_.PSObject.Properties.Name | Should -Contain 'Name'
                 $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
@@ -37,6 +38,7 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
 
             $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'QueriedGroup'
                 $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
                 $_.PSObject.Properties.Name | Should -Contain 'Name'
                 $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
@@ -53,6 +55,7 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
 
             $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'QueriedGroup'
                 $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
                 $_.PSObject.Properties.Name | Should -Contain 'Name'
                 $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
@@ -69,6 +72,7 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
 
             $actual | ForEach-Object {
+                $_.PSObject.Properties.Name | Should -Contain 'QueriedGroup'
                 $_.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
                 $_.PSObject.Properties.Name | Should -Contain 'Name'
                 $_.PSObject.Properties.Name | Should -Contain 'ObjectClass'
@@ -80,35 +84,42 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
         }
 
         It "Finds test group" {
-            $actual = Get-OpenADGroupMember -Identity 'TestGroup' -Session $session |
+            $group = Get-OpenADGroup -Identity 'TestGroup'
+            $actual = $group | Get-OpenADGroupMember -Session $session |
                 Sort-Object -Property SamAccountName
             $actual.Count | Should -Be 2
 
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[0].QueriedGroup | Should -Be $group.DistinguishedName
             $actual[0].SamAccountName | Should -Be 'TestGroupMember'
             $actual[0].ObjectClass | Should -Be 'user'
 
             $actual[1] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[1].QueriedGroup | Should -Be $group.DistinguishedName
             $actual[1].SamAccountName | Should -Be 'TestGroupSub'
             $actual[1].ObjectClass | Should -Be 'group'
         }
 
         It "Finds test group recursively" {
-            $actual = Get-OpenADGroupMember -Identity 'TestGroup' -Recursive -Session $session |
+            $group = Get-OpenADGroup -Identity 'TestGroup'
+            $actual = $group | Get-OpenADGroupMember -Recursive -Session $session |
                 Sort-Object -Property SamAccountName
             $actual.Count | Should -Be 2
 
             $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[0].QueriedGroup | Should -Be $group.DistinguishedName
             $actual[0].SamAccountName | Should -Be 'TestGroupMember'
             $actual[0].ObjectClass | Should -Be 'user'
 
             $actual[1] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[1].QueriedGroup | Should -Be $group.DistinguishedName
             $actual[1].SamAccountName | Should -Be 'TestGroupSubMember'
             $actual[1].ObjectClass | Should -Be 'user'
         }
 
         It "Requests a property that is not set" {
             $actual = Get-OpenADGroupMember -Session $session -Identity 'Administrators' -Property adminCount | Select-Object -First 1
+            $actual.PSObject.Properties.Name | Should -Contain 'QueriedGroup'
             $actual.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
             $actual.PSObject.Properties.Name | Should -Contain 'Name'
             $actual.PSObject.Properties.Name | Should -Contain 'ObjectClass'

--- a/tests/Get-OpenADGroupMember.Tests.ps1
+++ b/tests/Get-OpenADGroupMember.Tests.ps1
@@ -79,6 +79,34 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
             }
         }
 
+        It "Finds test group" {
+            $actual = Get-OpenADGroupMember -Identity 'TestGroup' -Session $session |
+                Sort-Object -Property SamAccountName
+            $actual.Count | Should -Be 2
+
+            $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[0].SamAccountName | Should -Be 'TestGroupMember'
+            $actual[0].ObjectClass | Should -Be 'user'
+
+            $actual[1] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[1].SamAccountName | Should -Be 'TestGroupSub'
+            $actual[1].ObjectClass | Should -Be 'group'
+        }
+
+        It "Finds test group recursively" {
+            $actual = Get-OpenADGroupMember -Identity 'TestGroup' -Recursive -Session $session |
+                Sort-Object -Property SamAccountName
+            $actual.Count | Should -Be 2
+
+            $actual[0] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[0].SamAccountName | Should -Be 'TestGroupMember'
+            $actual[0].ObjectClass | Should -Be 'user'
+
+            $actual[1] | Should -BeOfType ([PSOpenAD.OpenADPrincipal])
+            $actual[1].SamAccountName | Should -Be 'TestGroupSubMember'
+            $actual[1].ObjectClass | Should -Be 'user'
+        }
+
         It "Requests a property that is not set" {
             $actual = Get-OpenADGroupMember -Session $session -Identity 'Administrators' -Property adminCount | Select-Object -First 1
             $actual.PSObject.Properties.Name | Should -Contain 'DistinguishedName'
@@ -94,7 +122,7 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
         It "Requests a property that is not valid" {
             {
                 Get-OpenADGroupMember -Identity 'Administrators' -Session $session -Property sAMAccountName, invalid1, objectSid, invalid2 -ErrorAction Stop
-            } | Should -Throw -ExpectedMessage "One or more properties for 'top' class are not valid: 'invalid1', 'invalid2'"
+            } | Should -Throw -ExpectedMessage "One or more properties for person are not valid: 'invalid1', 'invalid2'"
         }
 
         It "Completes the properties selected" {

--- a/tools/setup-samba.sh
+++ b/tools/setup-samba.sh
@@ -53,4 +53,24 @@ cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 samba-tool contact add \
     MyTestContact
 
+samba-tool group add \
+    TestGroup
+
+samba-tool group add \
+    TestGroupSub
+
+samba-tool user create \
+    TestGroupMember Password01!
+
+samba-tool user create \
+    TestGroupSubMember Password01!
+
+samba-tool group addmembers \
+    TestGroup \
+    TestGroupSub,TestGroupMember
+
+samba-tool group addmembers \
+    TestGroupSub \
+    TestGroupSubMember
+
 samba --debug-stderr --foreground --no-process-group


### PR DESCRIPTION
Tidies up Get-OpenADGroupMember so it shared code with the common GetOpenADOperation base class. Expands on the documentation a bit and adds a few more tests.