### PR TITLE
SecurityIdentifier properties, methods, and operators

### DIFF
--- a/src/Security/SecurityIdentifier.cs
+++ b/src/Security/SecurityIdentifier.cs
@@ -125,7 +125,31 @@ public sealed class SecurityIdentifier
     /// </summary>
     public bool IsAccountSid()
         => _identifierAuthority == 5 && _subAuthorities.Length >= 4 && _subAuthorities[0] == 21;
-        // 21 is a fixed value used for "normal" issuing authorities
-        // Normal SID layout is 4 subauthorities and RID
-        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-azod/ecc7dfba-77e1-4e03-ab99-114b349c7164
+    // 21 is a fixed value used for "normal" issuing authorities
+    // Normal SID layout is 4 subauthorities and RID
+    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-azod/ecc7dfba-77e1-4e03-ab99-114b349c7164
+
+    /// <summary>
+    /// Test if the identifier belongs to the same domain as the specified SID
+    /// </summary>
+    public bool IsEqualDomainSid(SecurityIdentifier sid)
+    {
+        if (_identifierAuthority != 5 || sid._identifierAuthority != 5)
+        {
+            return false;
+        }
+        else if (IsAccountSid() && sid.IsAccountSid())
+        {
+            return AccountDomainSid!.Equals(sid.AccountDomainSid);
+        }
+        else if (_subAuthorities.Length >= 1 && _subAuthorities[0] == 32 &&
+                    sid._subAuthorities.Length >= 1 && _subAuthorities[0] == 32)
+        {
+            return _subAuthorities[0] == sid._subAuthorities[0];
+        }
+        else
+        {
+            return false;
+        }
+    }
 }

--- a/src/Security/SecurityIdentifier.cs
+++ b/src/Security/SecurityIdentifier.cs
@@ -99,4 +99,13 @@ public sealed class SecurityIdentifier
     }
 
     public override string ToString() => $"S-{_revision}-{_identifierAuthority}-" + String.Join("-", _subAuthorities);
+
+    /// <summary>
+    /// Test if the identifier is a valid Windows account SID.
+    /// </summary>
+    public bool IsAccountSid()
+        => _identifierAuthority == 5 && _subAuthorities.Length >= 4 && _subAuthorities[0] == 21;
+        // 21 is a fixed value used for "normal" issuing authorities
+        // Normal SID layout is 4 subauthorities and RID
+        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-azod/ecc7dfba-77e1-4e03-ab99-114b349c7164
 }

--- a/src/Security/SecurityIdentifier.cs
+++ b/src/Security/SecurityIdentifier.cs
@@ -152,4 +152,7 @@ public sealed class SecurityIdentifier
             return false;
         }
     }
+
+    public static bool operator ==(SecurityIdentifier a, SecurityIdentifier b) => a is null ? b is null : a.Equals(b);
+    public static bool operator !=(SecurityIdentifier a, SecurityIdentifier b) => !(a == b);
 }

--- a/src/Security/SecurityIdentifier.cs
+++ b/src/Security/SecurityIdentifier.cs
@@ -13,6 +13,26 @@ public sealed class SecurityIdentifier
 
     public string Value => ToString();
 
+    /// <value>
+    /// The domain SID of the identifier
+    /// </value>
+    public SecurityIdentifier? AccountDomainSid
+    {
+        get
+        {
+            if (IsAccountSid())
+            {
+                return new SecurityIdentifier(
+                    $"S-{_revision}-{_identifierAuthority}-" + String.Join("-", _subAuthorities[0..4])
+                );
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+
     public SecurityIdentifier(string sid)
     {
         Match m = Regex.Match(sid, @"^S-(?<revision>\d)-(?<authority>\d+)(?:-\d+){1,15}$");

--- a/src/Security/SecurityIdentifier.cs
+++ b/src/Security/SecurityIdentifier.cs
@@ -155,4 +155,12 @@ public sealed class SecurityIdentifier
 
     public static bool operator ==(SecurityIdentifier a, SecurityIdentifier b) => a is null ? b is null : a.Equals(b);
     public static bool operator !=(SecurityIdentifier a, SecurityIdentifier b) => !(a == b);
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static implicit operator System.Security.Principal.SecurityIdentifier(SecurityIdentifier sid)
+        => new System.Security.Principal.SecurityIdentifier(sid.Value);
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public static implicit operator SecurityIdentifier(System.Security.Principal.SecurityIdentifier sid)
+        => new SecurityIdentifier(sid.Value);
 }

--- a/tests/units/PSOpenADTests.csproj
+++ b/tests/units/PSOpenADTests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -125,4 +125,19 @@ public static class SecurityIdentifierTests
     {
         Assert.Equal(AccountDomainSid, (new SecurityIdentifier(sid)).AccountDomainSid?.ToString());
     }
+
+    [Theory]
+    [InlineData("S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681", "S-1-15-3-1", false)]
+    // Built-in SIDs https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
+    [InlineData("S-1-5-32-554", "S-1-5-32-544", true)]
+    // domainDNS objects don't have a RID, but do have a domain https://learn.microsoft.com/en-us/windows/win32/adschema/c-domaindns
+    [InlineData("S-1-5-21-3787635890-1162502339-3687787521", "S-1-5-21-3787635890-1162502339-3687787521", true)]
+    // Normal SIDs
+    [InlineData("S-1-5-21-3137669136-239306048-608292226-1001", "S-1-5-21-3137669136-239306048-608292226", true)]
+    [InlineData("S-1-5-21-3787635890-1162502339-3687787521-500", "S-1-5-21-3787635890-1162502339-3687787521", true)]
+    [InlineData("S-1-5-11", "S-1-5-11", false)]
+    public static void IsEqualDomainSidIsCorrect(string sidA, string sidB, bool expected)
+    {
+        Assert.Equal(expected, (new SecurityIdentifier(sidA)).IsEqualDomainSid(new SecurityIdentifier(sidB)));
+    }
 }

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -1,6 +1,7 @@
 using PSOpenAD.Security;
 using System;
 using Xunit;
+using System.Runtime.InteropServices;
 
 namespace PSOpenADTests;
 
@@ -162,10 +163,12 @@ public static class SecurityIdentifierTests
     {
         Assert.Equal(expected, (new SecurityIdentifier(sidA)).IsEqualDomainSid(new SecurityIdentifier(sidB)));
     }
-    
-    [Fact]
+
+    [SkippableFact]
     public static void SidRoundtrip()
     {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
         SecurityIdentifier sid = new SecurityIdentifier("S-1-5-12921-1921-943-12-3-5");
         System.Security.Principal.SecurityIdentifier winsid = (System.Security.Principal.SecurityIdentifier)sid;
         Assert.Equal(sid.Value, winsid.Value);

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -93,4 +93,19 @@ public static class SecurityIdentifierTests
 
         Assert.Equal("Destination array was not large enough.", ex.Message);
     }
+
+    [Theory]
+    // Capability SIDs aren't real accounts https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers#capability-sids
+    [InlineData("S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681", false)]
+    // Built-in SIDs https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
+    [InlineData("S-1-5-32-554", false)]
+    // domainDNS objects don't have a RID, but do have a domain https://learn.microsoft.com/en-us/windows/win32/adschema/c-domaindns
+    [InlineData("S-1-5-21-3787635890-1162502339-3687787521", true)]
+    // Normal SIDs
+    [InlineData("S-1-5-21-3137669136-239306048-608292226-1001", true)]
+    [InlineData("S-1-5-21-3787635890-1162502339-3687787521-500", true)]
+    public static void IsAccountSidIsCorrect(string sid, bool IsAccountSid)
+    {
+        Assert.Equal(IsAccountSid, (new SecurityIdentifier(sid)).IsAccountSid());
+    }
 }

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -108,4 +108,24 @@ public static class SecurityIdentifierTests
     {
         Assert.Equal(IsAccountSid, (new SecurityIdentifier(sid)).IsAccountSid());
     }
+
+    [Theory]
+    [InlineData("S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681", null)]
+    // Built-in SIDs https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
+    [InlineData("S-1-5-32-554", null)]
+    // domainDNS objects don't have a RID, but do have a domain https://learn.microsoft.com/en-us/windows/win32/adschema/c-domaindns
+    [InlineData("S-1-5-21-3787635890-1162502339-3687787521", "S-1-5-21-3787635890-1162502339-3687787521")]
+    // Normal SIDs
+    [InlineData("S-1-5-21-3137669136-239306048-608292226-1001", "S-1-5-21-3137669136-239306048-608292226")]
+    [InlineData("S-1-5-21-3787635890-1162502339-3687787521-500", "S-1-5-21-3787635890-1162502339-3687787521")]
+    public static void GetAccountDomainSidForAccountIdentifiers(string sid, string AccountDomainSid) {
+        if (string.IsNullOrEmpty(AccountDomainSid))
+        {
+            Assert.Null((new SecurityIdentifier(sid)).AccountDomainSid);
+        }
+        else
+        {
+            Assert.Equal(AccountDomainSid, (new SecurityIdentifier(sid)).AccountDomainSid.ToString());
+        }
+    }
 }

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -110,22 +110,19 @@ public static class SecurityIdentifierTests
     }
 
     [Theory]
-    [InlineData("S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681", null)]
-    // Built-in SIDs https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
-    [InlineData("S-1-5-32-554", null)]
-    // domainDNS objects don't have a RID, but do have a domain https://learn.microsoft.com/en-us/windows/win32/adschema/c-domaindns
+    [InlineData("S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681")]
+    [InlineData("S-1-5-32-554")]
+    public static void AccountDomainSidReturnsNullForNonAccountIdentifiers(string sid)
+    {
+        Assert.Null((new SecurityIdentifier(sid)).AccountDomainSid);
+    }
+
+    [Theory]
     [InlineData("S-1-5-21-3787635890-1162502339-3687787521", "S-1-5-21-3787635890-1162502339-3687787521")]
-    // Normal SIDs
     [InlineData("S-1-5-21-3137669136-239306048-608292226-1001", "S-1-5-21-3137669136-239306048-608292226")]
     [InlineData("S-1-5-21-3787635890-1162502339-3687787521-500", "S-1-5-21-3787635890-1162502339-3687787521")]
-    public static void GetAccountDomainSidForAccountIdentifiers(string sid, string AccountDomainSid) {
-        if (string.IsNullOrEmpty(AccountDomainSid))
-        {
-            Assert.Null((new SecurityIdentifier(sid)).AccountDomainSid);
-        }
-        else
-        {
-            Assert.Equal(AccountDomainSid, (new SecurityIdentifier(sid)).AccountDomainSid.ToString());
-        }
+    public static void AccountDomainSidReturnsDomainSidForAccountIdentifiers(string sid, string AccountDomainSid)
+    {
+        Assert.Equal(AccountDomainSid, (new SecurityIdentifier(sid)).AccountDomainSid?.ToString());
     }
 }

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -47,6 +47,28 @@ public static class SecurityIdentifierTests
     }
 
     [Fact]
+    public static void SidEqualsOperatorSid()
+    {
+        SecurityIdentifier sid1 = new SecurityIdentifier("S-1-5-19");
+        SecurityIdentifier sid2 = new SecurityIdentifier("S-1-5-19");
+        SecurityIdentifier sid3 = new SecurityIdentifier("S-1-5-18");
+
+        Assert.True(sid1 == sid2);
+        Assert.False(sid1 == sid3);
+    }
+
+    [Fact]
+    public static void SidNotEqualsOperatorSid()
+    {
+        SecurityIdentifier sid1 = new SecurityIdentifier("S-1-5-18");
+        SecurityIdentifier sid2 = new SecurityIdentifier("S-1-5-19");
+        SecurityIdentifier sid3 = new SecurityIdentifier("S-1-5-18");
+
+        Assert.True(sid1 != sid2);
+        Assert.False(sid1 != sid3);
+    }
+
+    [Fact]
     public static void SidNotEqualString()
     {
         SecurityIdentifier sid1 = new SecurityIdentifier("S-1-5-19");

--- a/tests/units/SecurityIdentifierTests.cs
+++ b/tests/units/SecurityIdentifierTests.cs
@@ -162,4 +162,14 @@ public static class SecurityIdentifierTests
     {
         Assert.Equal(expected, (new SecurityIdentifier(sidA)).IsEqualDomainSid(new SecurityIdentifier(sidB)));
     }
+    
+    [Fact]
+    public static void SidRoundtrip()
+    {
+        SecurityIdentifier sid = new SecurityIdentifier("S-1-5-12921-1921-943-12-3-5");
+        System.Security.Principal.SecurityIdentifier winsid = (System.Security.Principal.SecurityIdentifier)sid;
+        Assert.Equal(sid.Value, winsid.Value);
+        SecurityIdentifier newsid = (SecurityIdentifier)winsid;
+        Assert.Equal(sid.Value, newsid.Value);
+    }
 }


### PR DESCRIPTION
Add:
- `AccountDomainSid`
- `IsAccountSid()`
- `IsEqualDomainSid()`
- `==` and `!=` operators
- implicit conversion to/from `System.Security.Principal.SecurityIdentifier` on Windows
- `Xunit.SkippableFact` reference to support tests that only run on Windows https://github.com/AArnott/Xunit.SkippableFact

The behaviour for each matches `S.S.P.SecurityIdentifier`'s equivalent for every case I tried, but they're not tested against them.