### PR TITLE
Added Get-OpenADRootDSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 + Added the following cmdlets:
   + [New-OpenADObject](./docs/en-US/New-OpenADObject.md): Creates new AD objects
   + [Remove-OpenADObject](./docs/en-US/Remove-OpenADObject.md): Removes AD objects
+  + [Get-OpenADRootDSE](./docs/en-US/Get-OpenADRootDSE.md): Get the root directory server information tree
 + Fixed up `-LDAPFilter` logic to align the `\` escaping behaviour with OpenLDAP and the `Get-AD*` cmdlets
   + Before a filter with the char `\` had to have 2 more chars `[A-F0-9]` which represented the characters hex value
   + Now if the `\` does not have 2 characters after or they don't match the hex pattern, the `\` and subsequent values are treated literally

--- a/docs/en-US/Get-OpenADRootDSE.md
+++ b/docs/en-US/Get-OpenADRootDSE.md
@@ -1,0 +1,213 @@
+---
+external help file: PSOpenAD.Module.dll-Help.xml
+Module Name: PSOpenAD
+online version: https://www.github.com/jborean93/PSOpenAD/blob/main/docs/en-US/Get-OpenADRootDSE.md
+schema: 2.0.0
+---
+
+# Get-OpenADRootDSE
+
+## SYNOPSIS
+Gets the root of a directory server information tree.
+
+## SYNTAX
+
+### Session
+```
+Get-OpenADRootDSE [-Property <String[]>] -Session <OpenADSession> [<CommonParameters>]
+```
+
+### Server
+```
+Get-OpenADRootDSE [-Property <String[]>] [-Server <String>] [-AuthType <AuthenticationMethod>]
+ [-SessionOption <OpenADSessionOptions>] [-StartTLS] [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Get-OpenADRootDSE` cmdlet gets the object that represents the root of the directory information tree of a directory server.
+This tree provides information about the configuration and capabilities of the directory server, such as the distinguished name for the configuration container, the current time on the directory server, and the functional levels of the directory server and the domain.
+
+## EXAMPLES
+
+### Example 1: Get the root of a directory server information tree
+```powershell
+PS C:\> Get-OpenADRootDSE
+DomainController              : DC01.domain.test
+ConfigurationNamingContext    : CN=Configuration,DC=domain,DC=test
+CurrentTime                   : 4/9/2023 10:12:11pm +00:00
+DefaultNamingContext          : DC=domain,DC=test
+DnsHostName                   : DC01.domain.test
+DomainControllerFunctionality : Windows2016
+DomainFunctionality           : Windows2016Domain
+DsServiceName                 : CN=NTDS Settings,CN=DC01,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=domain,DC=test
+ForestFunctionality           : Windows2016Forest
+HighestCommittedUSN           : 1069399
+IsGlobalCatalogReady          : True
+IsSynchronized                : True
+LdapServiceName               : domain.test:dc01$@DOMAIN.TEST
+NamingContexts                : {DC=domain,DC=test, CN=Configuration,DC=domain,DC=test, CN=Schema,CN=Configuration,DC=domain,DC=test,
+                                DC=DomainDnsZones,DC=domain,DC=test…}
+RootDomainNamingContext       : DC=domain,DC=test
+SchemaNamingContext           : CN=Schema,CN=Configuration,DC=domain,DC=test
+ServerName                    : CN=DC01,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=domain,DC=test
+SubschemaSubentry             : CN=Aggregate,CN=Schema,CN=Configuration,DC=domain,DC=test
+SupportedCapabilities         : {1.2.840.113556.1.4.800 (LDAP_CAP_ACTIVE_DIRECTORY_OID), 1.2.840.113556.1.4.1670
+                                (LDAP_CAP_ACTIVE_DIRECTORY_V51_OID), 1.2.840.113556.1.4.1791 (LDAP_CAP_ACTIVE_DIRECTORY_LDAP_INTEG_OID),
+                                1.2.840.113556.1.4.1935 (LDAP_CAP_ACTIVE_DIRECTORY_V61_OID)…}
+SupportedControl              : {1.2.840.113556.1.4.319 (LDAP_PAGED_RESULT_OID_STRING), 1.2.840.113556.1.4.801 (LDAP_SERVER_SD_FLAGS_OID),
+                                1.2.840.113556.1.4.473 (LDAP_SERVER_SORT_OID), 1.2.840.113556.1.4.528 (LDAP_SERVER_NOTIFICATION_OID)…}
+SupportedLDAPPolicies         : {MaxPoolThreads, MaxPercentDirSyncRequests, MaxDatagramRecv, MaxReceiveBuffer…}
+SupportedLDAPVersion          : {3, 2}
+SupportedSASLMechanisms       : {GSSAPI, GSS-SPNEGO, EXTERNAL, DIGEST-MD5}
+```
+
+This command gets the root of the directory server information tree of the directory server from the default domain controller.
+
+### Example 2: Get the root of the directory server information tree with the specified property
+```powershell
+PS C:\> Get-OpenADRootDSE -Server Fabrikam-RODC1 -Property supportedExtension
+```
+
+This command gets the root of the directory server information, including the `supportedExtension` property for the domain controller `Fabrikam-RODC1`.
+
+## PARAMETERS
+
+### -AuthType
+The authentication type to use when creating the `OpenAD` session.
+This is used when the cmdlet creates a new connection to the `-Server` specified`.
+
+```yaml
+Type: AuthenticationMethod
+Parameter Sets: Server
+Aliases:
+Accepted values: Default, Anonymous, Simple, Negotiate, Kerberos, Certificate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+The explicit credentials to use when creating the `OpenAD` session.
+This is used when the cmdlet creates a new connection to the `-Server` specified.
+
+```yaml
+Type: PSCredential
+Parameter Sets: Server
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Property
+Specifies the properties/attributes to retrieve for the root DSE entry.
+Use this parameter to retrieve properties that are not included in the default set.
+
+All the extra properties requested are added as note properties on the output object.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Properties
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+The Active Directory server to connect to.
+This can either be the name of the server or the LDAP connection uri starting with `ldap://` or `ldaps://`.
+The derived URI of this value is used to find any existing connections that are available for use or will be used to create a new session if no cached session exists.
+If both `-Server` and `-Session` are not specified then the default Kerberos realm is used if available otherwise it will generate an error.
+This option supports tab completion based on the existing OpenADSessions that have been created.
+
+This option is mutually exclusive with `-Session`.
+
+```yaml
+Type: String
+Parameter Sets: Server
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Session
+The `OpenAD` session to use for the query rather than trying to create a new connection or reuse a cached connection.
+This session is generated by `New-OpenADSession` and can be used in situations where the global defaults should not be used.
+
+This option is mutually exclusive with `-Server`.
+
+```yaml
+Type: OpenADSession
+Parameter Sets: Session
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SessionOption
+Advanced session options used when creating a new session with `-Server`.
+These options can be generated with `New-OpenADSessionOption`.
+
+```yaml
+Type: OpenADSessionOptions
+Parameter Sets: Server
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartTLS
+Use `StartTLS` when creating a new session with `-Server`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Server
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+This cmdlet does not support any pipeline input.
+
+## OUTPUTS
+
+### PSOpenAD.OpenADEntity
+An object that contains the AD Root DSE properties.
+
+## NOTES
+
+## RELATED LINKS
+
+[MS-ADTS rootDSE Attributes](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/96f7b086-1ca3-4764-9a08-33f8f7a543db)

--- a/docs/en-US/PSOpenAD.md
+++ b/docs/en-US/PSOpenAD.md
@@ -29,6 +29,9 @@ Gets one or more Active Directory objects.
 ### [Get-OpenADPrincipalGroupMembership](Get-OpenADPrincipalGroupMembership.md)
 Get the Active Directory groups that an object belongs to.
 
+### [Get-OpenADRootDSE](Get-OpenADRootDSE.md)
+Gets the root of a directory server information tree.
+
 ### [Get-OpenADServiceAccount](Get-OpenADServiceAccount.md)
 Gets one or more Active Directory managed service accounts or group managed service accounts.
 

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -77,6 +77,7 @@
         'Get-OpenADGroupMember'
         'Get-OpenADObject'
         'Get-OpenADPrincipalGroupMembership'
+        'Get-OpenADRootDSE'
         'Get-OpenADServiceAccount'
         'Get-OpenADSession'
         'Get-OpenADUser'

--- a/src/PSOpenAD.Module/Commands/GetOpenADRootDSE.cs
+++ b/src/PSOpenAD.Module/Commands/GetOpenADRootDSE.cs
@@ -1,0 +1,84 @@
+using PSOpenAD.LDAP;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+
+namespace PSOpenAD.Module.Commands;
+
+[Cmdlet(
+    VerbsCommon.Get, "OpenADRootDSE"
+)]
+[OutputType(typeof(OpenADEntity))]
+public class GetOpenADRootDSE : OpenADSessionCmdletBase
+{
+    [Parameter()]
+    [Alias("Properties")]
+    [ValidateNotNullOrEmpty]
+    public string[]? Property { get; set; }
+
+    private string[] _defaultAttributes = new[]
+    {
+        "configurationNamingContext",
+        "currentTime",
+        "defaultNamingContext",
+        "dnsHostName",
+        "domainControllerFunctionality",
+        "domainFunctionality",
+        "dsServiceName",
+        "forestFunctionality",
+        "highestCommittedUSN",
+        "isGlobalCatalogReady",
+        "isSynchronized",
+        "ldapServiceName",
+        "namingContexts",
+        "rootDomainNamingContext",
+        "schemaNamingContext",
+        "serverName",
+        "subschemaSubentry",
+        "supportedCapabilities",
+        "supportedControl",
+        "supportedLDAPPolicies",
+        "supportedLDAPVersion",
+        "supportedSASLMechanisms",
+    };
+
+    protected override void ProcessRecordWithSession(OpenADSession session)
+    {
+        HashSet<string> requestedProps = _defaultAttributes
+            .Union(Property ?? Array.Empty<string>())
+            .ToHashSet();
+        SearchResultEntry? searchRes = Operations.LdapSearchRequest(
+            session.Connection,
+            "",
+            SearchScope.Base,
+            0,
+            session.OperationTimeout,
+            new FilterPresent("objectClass"),
+            requestedProps.ToArray(),
+            controls: null,
+            cancelToken: CancelToken,
+            cmdlet: this,
+            ignoreErrors: true
+        ).FirstOrDefault();
+        if (searchRes == null)
+        {
+            ErrorRecord err = new(
+                new ItemNotFoundException("Cannot find AD RootDSE object"),
+                "RootDSENotFound",
+                ErrorCategory.ObjectNotFound,
+                null);
+            WriteError(err);
+            return;
+        }
+
+        OpenADEntity rootDse = GetOpenADObject.CreateOutputObject(
+            session,
+            searchRes,
+            requestedProps,
+            static (a) => new OpenADEntity(a),
+            this
+        );
+        WriteObject(rootDse);
+    }
+}

--- a/src/PSOpenAD.Module/Commands/NewOpenAD.cs
+++ b/src/PSOpenAD.Module/Commands/NewOpenAD.cs
@@ -162,7 +162,7 @@ public class NewOpenADObject : OpenADSessionCmdletBase
             return;
         }
 
-        OpenADObject resultObj = GetOpenADObject.CreateOutputObject(
+        OpenADEntity resultObj = GetOpenADObject.CreateOutputObject(
             session,
             searchResult,
             searchProperties,

--- a/src/PSOpenAD.Module/Commands/OpenADWhoami.cs
+++ b/src/PSOpenAD.Module/Commands/OpenADWhoami.cs
@@ -13,7 +13,7 @@ public class GetOpenADWhoami : OpenADSessionCmdletBase
 {
     protected override void ProcessRecordWithSession(OpenADSession session)
     {
-        int whoamiId = session.Ldap.ExtendedRequest("1.3.6.1.4.1.4203.1.11.3");
+        int whoamiId = session.Ldap.ExtendedRequest(ExtendedOperations.LDAP_SERVER_WHO_AM_I_OID);
         ExtendedResponse extResp = (ExtendedResponse)session.Connection.WaitForMessage(whoamiId,
             cancelToken: CancelToken);
         if (extResp.Result.ResultCode != LDAPResultCode.Success)

--- a/src/PSOpenAD.Module/OpenADSessionFactory.cs
+++ b/src/PSOpenAD.Module/OpenADSessionFactory.cs
@@ -232,7 +232,7 @@ internal sealed class OpenADSessionFactory
         else if (startTls)
         {
             cmdlet.WriteVerbose("Sending StartTLS request to the server");
-            int startTlsId = connection.Session.ExtendedRequest("1.3.6.1.4.1.1466.20037");
+            int startTlsId = connection.Session.ExtendedRequest(ExtendedOperations.LDAP_SERVER_START_TLS_OID);
 
             ExtendedResponse extResp = (ExtendedResponse)connection.WaitForMessage(startTlsId,
                 cancelToken: cancelToken);

--- a/src/PSOpenAD/LDAP/ExtendedOperations.cs
+++ b/src/PSOpenAD/LDAP/ExtendedOperations.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace PSOpenAD.LDAP;
+
+public static class ExtendedOperations
+{
+    public const string LDAP_SERVER_FAST_BIND_OID = "1.2.840.113556.1.4.1781";
+    public const string LDAP_SERVER_BATCH_REQUEST_OID = "1.2.840.113556.1.4.2212";
+    public const string LDAP_TTL_REFRESH_OID = "1.3.6.1.4.1.1466.101.119.1";
+    public const string LDAP_SERVER_START_TLS_OID = "1.3.6.1.4.1.1466.20037";
+    public const string LDAP_SERVER_WHO_AM_I_OID = "1.3.6.1.4.1.4203.1.11.3";
+}

--- a/src/PSOpenAD/Schema.cs
+++ b/src/PSOpenAD/Schema.cs
@@ -5,6 +5,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using System.Reflection;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
@@ -12,22 +14,27 @@ namespace PSOpenAD;
 
 internal static class DefaultOverrider
 {
-    public delegate object CustomTransform(string attribute, ReadOnlySpan<byte> value);
+    public delegate (object, bool?) CustomTransform(string attribute, ReadOnlySpan<byte> value);
 
     internal static Dictionary<string, CustomTransform> Overrides { get; } = DefaultOverrides();
 
+    private static PSCodeMethod OidToStringMethod = new(
+        "ToString",
+        typeof(DefaultOverrider).GetMethod(nameof(OidToString), BindingFlags.Public | BindingFlags.Static)!);
+
     private static Dictionary<string, CustomTransform> DefaultOverrides()
     {
-        // These are known attributes that can map to a more user friendly value. Unfortunately these details
-        // aren't stored in the schema so they need to be manually mapped.
+
         return new Dictionary<string, CustomTransform>()
         {
+            // These are known attributes that can map to a more user friendly value. Unfortunately these details
+            // aren't stored in the schema so they need to be manually mapped.
             { "accountExpires", (_, v) => ParseFileTimeValue(v) },
             { "badPasswordTime", (_, v) => ParseFileTimeValue(v) },
             { "creationTime", (_, v) => ParseFileTimeValue(v) },
             { "forceLogoff", (_, v) => ParseTimeSpanValue(v) },
-            { "groupType", (_, v) => (GroupType)(int)SyntaxDefinition.ReadInteger(v) },
-            { "instanceType", (_, v) => (InstanceType)(int)SyntaxDefinition.ReadInteger(v) },
+            { "groupType", (_, v) => ParseEnumValue<GroupType>(v) },
+            { "instanceType", (_, v) => ParseEnumValue<InstanceType>(v) },
             { "lastLogoff", (_, v) => ParseFileTimeValue(v) },
             { "lastLogon", (_, v) => ParseFileTimeValue(v) },
             { "lastLogonTimestamp", (_, v) => ParseFileTimeValue(v) },
@@ -35,43 +42,170 @@ internal static class DefaultOverrider
             { "lockOutObservationWindow", (_, v) => ParseTimeSpanValue(v) },
             { "maxPwdAge", (_, v) => ParseTimeSpanValue(v) },
             { "minPwdAge", (_, v) => ParseTimeSpanValue(v) },
-            { "msDFS-GenerationGUIDv2", (_, v) => new Guid(v) },
-            { "msDFS-LinkIdentityGUIDv2", (_, v) => new Guid(v) },
-            { "msDFS-NamespaceIdentityGUIDv2", (_, v) => new Guid(v) },
-            { "msDFS-TargetListv2", (_, v) => Encoding.Unicode.GetString(v ) },
-            { "msDFSR-ContentSetGuid", (_, v) => new Guid(v) },
-            { "msDFSR-ReplicationGroupGuid", (_, v) => new Guid(v) },
-            { "msDS-SupportedEncryptionTypes", (
-                (_, v) => (SupportedEncryptionTypes)(int)SyntaxDefinition.ReadInteger(v)
-            ) },
-            { "objectGUID", (_, v) => new Guid(v) },
-            { "objectSid", (_, v) => new SecurityIdentifier(v) },
+            { "msDFS-GenerationGUIDv2", (_, v) => (new Guid(v), null) },
+            { "msDFS-LinkIdentityGUIDv2", (_, v) => (new Guid(v), null) },
+            { "msDFS-NamespaceIdentityGUIDv2", (_, v) => (new Guid(v), null) },
+            { "msDFS-TargetListv2", (_, v) => (Encoding.Unicode.GetString(v), null) },
+            { "msDFSR-ContentSetGuid", (_, v) => (new Guid(v), null) },
+            { "msDFSR-ReplicationGroupGuid", (_, v) => (new Guid(v), null) },
+            { "msDS-SupportedEncryptionTypes", (_, v) => ParseEnumValue<SupportedEncryptionTypes>(v) },
+            { "objectGUID", (_, v) => (new Guid(v), null) },
+            { "objectSid", (_, v) => (new SecurityIdentifier(v), null) },
             { "priorSetTime", (_, v) => ParseFileTimeValue(v) },
             { "pwdLastSet", (_, v) => ParseFileTimeValue(v) },
-            { "pwdProperties", (_, v) => (PasswordProperties)(int)SyntaxDefinition.ReadInteger(v) },
-            { "sAMAccountType", (_, v) => (SAMAccountType)(int)SyntaxDefinition.ReadInteger(v) },
-            { "systemFlags", (_, v) => (SystemFlags)(int)SyntaxDefinition.ReadInteger(v) },
-            { "userAccountControl", (_, v) => (UserAccountControl)(int)SyntaxDefinition.ReadInteger(v) },
-            { "userCertificate", (_, v) => new X509Certificate2(v.ToArray() ) },
+            { "pwdProperties", (_, v) => ParseEnumValue<PasswordProperties>(v) },
+            { "sAMAccountType", (_, v) => ParseEnumValue<SAMAccountType>(v) },
+            { "systemFlags", (_, v) => ParseEnumValue<SystemFlags>(v) },
+            { "userAccountControl", (_, v) => ParseEnumValue<UserAccountControl>(v) },
+            { "userCertificate", (_, v) => (new X509Certificate2(v.ToArray()), null ) },
+
+            // These are the RootDSE attributes that aren't present in the schema so manually define them.
+            // Non-operational (default)
+            { "configurationNamingContext", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "currentTime", (_, v) => (SyntaxDefinition.ReadUTCTime(v), true) },
+            { "defaultNamingContext", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "dnsHostName", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "domainControllerFunctionality", (_, v) => ParseEnumValue<ADDomainControllerMode>(v, isSingleValue: true) },
+            { "domainFunctionality", (_, v) => ParseEnumValue<ADDomainMode>(v, isSingleValue: true) },
+            { "dsServiceName", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "forestFunctionality", (_, v) => ParseEnumValue<ADForestMode>(v, isSingleValue: true) },
+            { "highestCommittedUSN", (_, v) => ((long)SyntaxDefinition.ReadInteger(v), true) },
+            { "isGlobalCatalogReady", (_, v) => (SyntaxDefinition.ReadDirectoryString(v) == "TRUE", true) },
+            { "isSynchronized", (_, v) => (SyntaxDefinition.ReadDirectoryString(v) == "TRUE", true) },
+            { "ldapServiceName", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "rootDomainNamingContext", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "schemaNamingContext", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "serverName", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "subschemaSubentry", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "supportedCapabilities", (_, v) => ParseOidValue(v) },
+            { "supportedControl", (_, v) => ParseOidValue(v) },
+            { "supportedLDAPVersion", (_, v) => ((long)SyntaxDefinition.ReadInteger(v), false) },
+
+            // Operational (explicitly requested)
+            { "dsSchemaAttrCount", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "dsSchemaClassCount", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "dsSchemaPrefixCount", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "supportedExtension", (_, v) => ParseOidValue(v) },
+            { "dsaVersionString", (_, v) => (SyntaxDefinition.ReadDirectoryString(v), true) },
+            { "msDS-PortLDAP", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "msDS-PortSSL", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "spnRegistrationResult", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "tokenGroups", (_, v) => (new SecurityIdentifier(v), false) },
+            { "usnAtRifm", (_, v) => ((long)SyntaxDefinition.ReadInteger(v), true) },
+            { "approximateHighestInternalObjectID", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
+            { "databaseGuid", (_, v) => (new Guid(SyntaxDefinition.ReadDirectoryString(v)), true) },
+            { "schemaIndexUpdateState", (_, v) => ((int)SyntaxDefinition.ReadInteger(v), true) },
         };
     }
 
-    internal static TimeSpan ParseTimeSpanValue(ReadOnlySpan<byte> value)
+    internal static (TimeSpan, bool?) ParseTimeSpanValue(ReadOnlySpan<byte> value)
     {
         Int64 raw = (Int64)SyntaxDefinition.ReadInteger(value);
         if (raw == Int64.MaxValue)
-            return new TimeSpan(0);
+            return (new TimeSpan(0), null);
         else
-            return new TimeSpan(raw);
+            return (new TimeSpan(raw), null);
     }
 
-    internal static DateTimeOffset ParseFileTimeValue(ReadOnlySpan<byte> value)
+    internal static (DateTimeOffset, bool?) ParseFileTimeValue(ReadOnlySpan<byte> value)
     {
         Int64 raw = (Int64)SyntaxDefinition.ReadInteger(value);
         if (raw == Int64.MaxValue)
-            return new DateTimeOffset(DateTime.FromFileTimeUtc(0));
+            return (new DateTimeOffset(DateTime.FromFileTimeUtc(0)), null);
         else
-            return new DateTimeOffset(DateTime.FromFileTimeUtc(raw));
+            return (new DateTimeOffset(DateTime.FromFileTimeUtc(raw)), null);
+    }
+
+    internal static (T, bool?) ParseEnumValue<T>(ReadOnlySpan<byte> value, bool? isSingleValue = null)
+    {
+        int raw = (int)SyntaxDefinition.ReadInteger(value);
+        return ((T)Enum.ToObject(typeof(T), raw), isSingleValue);
+    }
+
+    internal static (Oid, bool?) ParseOidValue(ReadOnlySpan<byte> value)
+    {
+        Dictionary<string, string> oidLookup = new()
+        {
+            // Known extended controls
+            { PagedResultControl.LDAP_PAGED_RESULT_OID_STRING, nameof(PagedResultControl.LDAP_PAGED_RESULT_OID_STRING) },
+            { ShowDeleted.LDAP_SERVER_SHOW_DELETED_OID, nameof(ShowDeleted.LDAP_SERVER_SHOW_DELETED_OID) },
+            { "1.2.840.113556.1.4.473", "LDAP_SERVER_SORT_OID" },
+            { "1.2.840.113556.1.4.474", "LDAP_SERVER_RESP_SORT_OID" },
+            { "1.2.840.113556.1.4.521", "LDAP_SERVER_CROSSDOM_MOVE_TARGET_OID" },
+            { "1.2.840.113556.1.4.528", "LDAP_SERVER_NOTIFICATION_OID" },
+            { "1.2.840.113556.1.4.529", "LDAP_SERVER_EXTENDED_DN_OID" },
+            { "1.2.840.113556.1.4.619", "LDAP_SERVER_LAZY_COMMIT_OID" },
+            { "1.2.840.113556.1.4.801", "LDAP_SERVER_SD_FLAGS_OID" },
+            { "1.2.840.113556.1.4.802", "LDAP_SERVER_RANGE_OPTION_OID" },
+            { "1.2.840.113556.1.4.805", "LDAP_SERVER_TREE_DELETE_OID" },
+            { "1.2.840.113556.1.4.841", "LDAP_SERVER_DIRSYNC_OID" },
+            { "1.2.840.113556.1.4.970", "LDAP_SERVER_GET_STATS_OID" },
+            { "1.2.840.113556.1.4.1338", "LDAP_SERVER_VERIFY_NAME_OID" },
+            { "1.2.840.113556.1.4.1339", "LDAP_SERVER_DOMAIN_SCOPE_OID" },
+            { "1.2.840.113556.1.4.1340", "LDAP_SERVER_SEARCH_OPTIONS_OID" },
+            { "1.2.840.113556.1.4.1341", "LDAP_SERVER_RODC_DCPROMO_OID" },
+            { "1.2.840.113556.1.4.1413", "LDAP_SERVER_PERMISSIVE_MODIFY_OID" },
+            { "1.2.840.113556.1.4.1504", "LDAP_SERVER_ASQ_OID" },
+            { "1.2.840.113556.1.4.1852", "LDAP_SERVER_QUOTA_CONTROL_OID" },
+            { "1.2.840.113556.1.4.1907", "LDAP_SERVER_SHUTDOWN_NOTIFY_OID" },
+            { "1.2.840.113556.1.4.1948", "LDAP_SERVER_RANGE_RETRIEVAL_NOERR_OID" },
+            { "1.2.840.113556.1.4.1974", "LDAP_SERVER_FORCE_UPDATE_OID" },
+            { "1.2.840.113556.1.4.2026", "LDAP_SERVER_DN_INPUT_OID" },
+            { "1.2.840.113556.1.4.2064", "LDAP_SERVER_SHOW_RECYCLED_OID" },
+            { ShowDeactivatedLink.LDAP_SERVER_SHOW_DEACTIVATED_LINK_OID, nameof(ShowDeactivatedLink.LDAP_SERVER_SHOW_DEACTIVATED_LINK_OID) },
+            { "1.2.840.113556.1.4.2066", "LDAP_SERVER_POLICY_HINTS_DEPRECATED_OID" },
+            { "1.2.840.113556.1.4.2090", "LDAP_SERVER_DIRSYNC_EX_OID" },
+            { "1.2.840.113556.1.4.2204", "LDAP_SERVER_TREE_DELETE_EX_OID" },
+            { "1.2.840.113556.1.4.2205", "LDAP_SERVER_UPDATE_STATS_OID" },
+            { "1.2.840.113556.1.4.2206", "LDAP_SERVER_SEARCH_HINTS_OID" },
+            { "1.2.840.113556.1.4.2211", "LDAP_SERVER_EXPECTED_ENTRY_COUNT_OID" },
+            { "1.2.840.113556.1.4.2239", "LDAP_SERVER_POLICY_HINTS_OID" },
+            { "1.2.840.113556.1.4.2255", "LDAP_SERVER_SET_OWNER_OID" },
+            { "1.2.840.113556.1.4.2256", "LDAP_SERVER_BYPASS_QUOTA_OID" },
+            { "1.2.840.113556.1.4.2309", "LDAP_SERVER_LINK_TTL_OID" },
+            { "1.2.840.113556.1.4.2330", "LDAP_SERVER_SET_CORRELATION_ID_OID" },
+            { "1.2.840.113556.1.4.2354", "LDAP_SERVER_THREAD_TRACE_OVERRIDE_OID" },
+            { "2.16.840.1.113730.3.4.9", "LDAP_CONTROL_VLVREQUEST" },
+            { "2.16.840.1.113730.3.4.10", "LDAP_CONTROL_VLVRESPONSE" },
+
+            // Known extended capabilities
+            { "1.2.840.113556.1.4.800", "LDAP_CAP_ACTIVE_DIRECTORY_OID" },
+            { "1.2.840.113556.1.4.1670", "LDAP_CAP_ACTIVE_DIRECTORY_V51_OID" },
+            { "1.2.840.113556.1.4.1791", "LDAP_CAP_ACTIVE_DIRECTORY_LDAP_INTEG_OID" },
+            { "1.2.840.113556.1.4.1851", "LDAP_CAP_ACTIVE_DIRECTORY_ADAM_OID" },
+            { "1.2.840.113556.1.4.1880", "LDAP_CAP_ACTIVE_DIRECTORY_ADAM_DIGEST_OID" },
+            { "1.2.840.113556.1.4.1920", "LDAP_CAP_ACTIVE_DIRECTORY_PARTIAL_SECRETS_OID" },
+            { "1.2.840.113556.1.4.1935", "LDAP_CAP_ACTIVE_DIRECTORY_V61_OID" },
+            { "1.2.840.113556.1.4.2080", "LDAP_CAP_ACTIVE_DIRECTORY_V61_R2_OID" },
+            { "1.2.840.113556.1.4.2237", "LDAP_CAP_ACTIVE_DIRECTORY_W8_OID" },
+
+            // Known extended operations
+            { ExtendedOperations.LDAP_SERVER_FAST_BIND_OID, nameof(ExtendedOperations.LDAP_SERVER_FAST_BIND_OID) },
+            { ExtendedOperations.LDAP_SERVER_BATCH_REQUEST_OID, nameof(ExtendedOperations.LDAP_SERVER_BATCH_REQUEST_OID) },
+            { ExtendedOperations.LDAP_TTL_REFRESH_OID, nameof(ExtendedOperations.LDAP_TTL_REFRESH_OID) },
+            { ExtendedOperations.LDAP_SERVER_START_TLS_OID, nameof(ExtendedOperations.LDAP_SERVER_START_TLS_OID) },
+            { ExtendedOperations.LDAP_SERVER_WHO_AM_I_OID, nameof(ExtendedOperations.LDAP_SERVER_WHO_AM_I_OID) },
+        };
+        string raw = SyntaxDefinition.ReadDirectoryString(value);
+
+        Oid oid;
+        if (oidLookup.ContainsKey(raw))
+        {
+            oid = new(raw, oidLookup[raw]);
+        }
+        else
+        {
+            oid = new(raw);
+        }
+        PSObject.AsPSObject(oid).Members.Add(OidToStringMethod);
+
+        return (oid, null);
+    }
+
+    public static string OidToString(PSObject value)
+    {
+        Oid oid = (Oid)value.BaseObject;
+        return string.IsNullOrWhiteSpace(oid.FriendlyName) ? oid.Value! : $"{oid.Value} ({oid.FriendlyName})";
     }
 }
 
@@ -216,6 +350,7 @@ internal sealed class SchemaMetadata
         if (DefaultOverrider.Overrides.ContainsKey(attribute))
             customTransform = DefaultOverrider.Overrides[attribute];
 
+        bool? isSingleValue = null;
         List<PSObject> processed = new();
         foreach (byte[] val in value)
         {
@@ -225,7 +360,7 @@ internal sealed class SchemaMetadata
                 object raw;
                 if (customTransform != null)
                 {
-                    raw = customTransform(attribute, val);
+                    (raw, isSingleValue) = customTransform(attribute, val);
                 }
                 else
                 {
@@ -248,7 +383,7 @@ internal sealed class SchemaMetadata
             processed.Add(parsed);
         }
 
-        return (processed.ToArray(), attrInfo?.SingleValue ?? false);
+        return (processed.ToArray(), isSingleValue ?? attrInfo?.SingleValue ?? false);
     }
 
     internal static byte[][] ConvertToRawAttributeCollection(object? value)

--- a/tests/Get-OpenADRootDSE.Tests.ps1
+++ b/tests/Get-OpenADRootDSE.Tests.ps1
@@ -1,0 +1,81 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
+    BeforeAll {
+        $selectedCred = $PSOpenADSettings.Credentials | Select-Object -First 1
+        $cred = [pscredential]::new($selectedCred.Username, $selectedCred.Password)
+
+        $session = New-OpenADSession -ComputerName $PSOpenADSettings.Server -Credential $cred
+    }
+
+    AfterAll {
+        Get-OpenADSession | Remove-OpenADSession
+    }
+
+    Context "Get-OpenADRootDSE" {
+        It "Gets default properties" {
+            $actual = Get-OpenADRootDSE
+            $actual | Should -BeOfType ([PSOpenAD.OpenADEntity])
+            $actual.PSObject.Properties.Name | Should -Contain 'ConfigurationNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'CurrentTime'
+            $actual.PSObject.Properties.Name | Should -Contain 'DefaultNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'DnsHostName'
+            $actual.PSObject.Properties.Name | Should -Contain 'DomainControllerFunctionality'
+            $actual.PSObject.Properties.Name | Should -Contain 'DomainFunctionality'
+            $actual.PSObject.Properties.Name | Should -Contain 'DsServiceName'
+            $actual.PSObject.Properties.Name | Should -Contain 'ForestFunctionality'
+            $actual.PSObject.Properties.Name | Should -Contain 'HighestCommittedUSN'
+            $actual.PSObject.Properties.Name | Should -Contain 'IsGlobalCatalogReady'
+            $actual.PSObject.Properties.Name | Should -Contain 'IsSynchronized'
+            $actual.PSObject.Properties.Name | Should -Contain 'LdapServiceName'
+            $actual.PSObject.Properties.Name | Should -Contain 'NamingContexts'
+            $actual.PSObject.Properties.Name | Should -Contain 'RootDomainNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'SchemaNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'ServerName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SubschemaSubentry'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedCapabilities'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedControl'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedLDAPPolicies'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedLDAPVersion'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedSASLMechanisms'
+            $actual.DomainController | Should -Be $PSOpenADSettings.Server
+        }
+
+        It "Gets extra properties" {
+            $actual = Get-OpenADRootDSE -Property supportedExtension
+            $actual | Should -BeOfType ([PSOpenAD.OpenADEntity])
+            $actual.PSObject.Properties.Name | Should -Contain 'ConfigurationNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'CurrentTime'
+            $actual.PSObject.Properties.Name | Should -Contain 'DefaultNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'DnsHostName'
+            $actual.PSObject.Properties.Name | Should -Contain 'DomainControllerFunctionality'
+            $actual.PSObject.Properties.Name | Should -Contain 'DomainFunctionality'
+            $actual.PSObject.Properties.Name | Should -Contain 'DsServiceName'
+            $actual.PSObject.Properties.Name | Should -Contain 'ForestFunctionality'
+            $actual.PSObject.Properties.Name | Should -Contain 'HighestCommittedUSN'
+            $actual.PSObject.Properties.Name | Should -Contain 'IsGlobalCatalogReady'
+            $actual.PSObject.Properties.Name | Should -Contain 'IsSynchronized'
+            $actual.PSObject.Properties.Name | Should -Contain 'LdapServiceName'
+            $actual.PSObject.Properties.Name | Should -Contain 'NamingContexts'
+            $actual.PSObject.Properties.Name | Should -Contain 'RootDomainNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'SchemaNamingContext'
+            $actual.PSObject.Properties.Name | Should -Contain 'ServerName'
+            $actual.PSObject.Properties.Name | Should -Contain 'SubschemaSubentry'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedCapabilities'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedControl'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedLDAPPolicies'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedLDAPVersion'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedSASLMechanisms'
+            $actual.PSObject.Properties.Name | Should -Contain 'SupportedExtension'
+            $actual.DomainController | Should -Be $PSOpenADSettings.Server
+
+            # Samba doesn't return this value so will be $null
+            if ($actual.SupportedExtension) {
+                $actual.SupportedExtension | ForEach-Object {
+                    $_ | Should -BeOfType ([System.Security.Cryptography.Oid])
+                    $_.ToString() | Should -BeLike '* (*)'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the cmdlet Get-OpenADRootDSE which can get the root directory server information like the subschemaSubentry, supportedControl, supportedCapabilities, and more. This replicates the behaviour of the Get-ADRootDSE cmdlet.