### PR TITLE
Fix up SSPI context lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSOpenAD
 
+## v0.4.1 - TBD
+
++ Fix up safe SSPI context handle lifetime handling to avoid process crash
+
 ## v0.4.0 - 2023-09-05
 
 + Moved module code into a separate Assembly Load Context to avoid assembly conflicts for dependencies

--- a/PSOpenAD.build.ps1
+++ b/PSOpenAD.build.ps1
@@ -90,8 +90,6 @@ task Sign {
         return
     }
 
-    Import-Module -Name (Join-Path $ReleasePath "$ModuleName.psd1") -ErrorAction Stop
-
     $key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert
     $signParams = @{
         Key = $key

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'PSOpenAD.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '0.4.0'
+    ModuleVersion          = '0.4.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
Fix the safe handle lifetime of the SSPI context and credential handles. This should avoid any process crashes due to it freeing a handle when it shouldn't.