### PR TITLE
Handle unknown DNS lookup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSOpenAD
 
+## v0.5.1 - TBD
+
++ Ensure a failure in a DNS lookup does not stop the module from importing but only errors when the value is used.
+
 ## v0.5.0 - 2024-03-21
 
 + Added the following cmdlets:

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'PSOpenAD.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '0.5.0'
+    ModuleVersion          = '0.5.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSOpenAD.Module/OnImportAndRemove.cs
+++ b/src/PSOpenAD.Module/OnImportAndRemove.cs
@@ -217,7 +217,11 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                         }
                         catch (DnsResponseException e)
                         {
-                            GlobalState.DefaultDCError = $"Error looking up SRV records for _ldap._tcp.{baseDomain}: {e.Message}";
+                            GlobalState.DefaultDCError = $"DNS Error looking up SRV records for _ldap._tcp.{baseDomain}: {e.Message}";
+                        }
+                        catch (Exception e)
+                        {
+                            GlobalState.DefaultDCError = $"Unknown error looking up SRV records for _ldap._tcp.{baseDomain}: {e.GetType().Name} - {e.Message}";
                         }
                     }
                 }


### PR DESCRIPTION
Handles any exception when failing to lookup the SRV record for the default realm. The error will still be shown when the value is used but now the module will still import.

Fixes: https://github.com/jborean93/PSOpenAD/issues/79