### PR TITLE
Use case insensitive check for requested props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.1 - TBD
 
 + Ensure a failure in a DNS lookup does not stop the module from importing but only errors when the value is used.
++ Use a case insensitive lookup for requested properties and the returned LDAP attributes
 
 ## v0.5.0 - 2024-03-21
 

--- a/src/PSOpenAD.Module/Commands/GetOpenAD.cs
+++ b/src/PSOpenAD.Module/Commands/GetOpenAD.cs
@@ -13,7 +13,7 @@ internal delegate OpenADEntity CreateADObjectDelegate(Dictionary<string, (PSObje
 public abstract class GetOpenADOperation<T> : OpenADSessionCmdletBase
     where T : ADObjectIdentity
 {
-    internal StringComparer _caseInsensitiveComparer = StringComparer.OrdinalIgnoreCase;
+    internal static StringComparer _caseInsensitiveComparer = StringComparer.OrdinalIgnoreCase;
 
     internal bool _includeDeleted = false;
 
@@ -280,7 +280,7 @@ public abstract class GetOpenADOperation<T> : OpenADSessionCmdletBase
         PSCmdlet? cmdlet
     )
     {
-        Dictionary<string, (PSObject[], bool)> props = new();
+        Dictionary<string, (PSObject[], bool)> props = new(_caseInsensitiveComparer);
         foreach (PartialAttribute attribute in result.Attributes)
         {
             props[attribute.Name] = session.SchemaMetadata.TransformAttributeValue(

--- a/tests/Get-OpenADObject.Tests.ps1
+++ b/tests/Get-OpenADObject.Tests.ps1
@@ -47,6 +47,11 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $err[0].Exception.Message | Should -BeLike "Cannot find an object with identity filter: '(&(objectClass=*)(distinguishedName=invalid-id))' under: *"
         }
 
+        It "Requests non-default property with case insensitive name" {
+            $actual = Get-OpenADObject -Session $session -Identity $session.DefaultNamingContext -Property ServerState
+            $actual.ServerState | Should -Be 1
+        }
+
         It "Does not fail if no match on filter" {
             $actual = Get-OpenADObject -Session $session -LDAPFilter '(objectClass=some-invalid-class)'
             $actual | Should -BeNullOrEmpty


### PR DESCRIPTION
Ensure that the requested properties are looked up using a case insensitive check against the returns LDAP attributes.

Fixes: https://github.com/jborean93/PSOpenAD/issues/82