### PR TITLE
Remove length check for sAMAccountName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.6.1 - TBD
 
++ Remove length check for `sAMAccountName` when used in the `-Identity` parameter
+
 ## v0.6.0 - 2025-03-12
 
 + Raised minimum PowerShell version to 7.4

--- a/src/PSOpenAD/ADIdentity.cs
+++ b/src/PSOpenAD/ADIdentity.cs
@@ -106,7 +106,7 @@ public class ADPrincipalIdentity : ADObjectIdentity
     {
         filter = new FilterPresent("");
 
-        Match m = Regex.Match(value, @"^(?:[^:*?""<>|\/\\]+\\)?(?<username>[^;:""<>|?,=\*\+\\\(\)]{1,20})$");
+        Match m = Regex.Match(value, @"^(?:[^:*?""<>|\/\\]+\\)?(?<username>[^;:""<>|?,=\*\+\\\(\)]+)$");
         if (m.Success)
         {
             string username = m.Groups["username"].Value;

--- a/src/PSOpenAD/PSOpenAD.csproj
+++ b/src/PSOpenAD/PSOpenAD.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
     <InternalsVisibleTo Include="PSOpenADTests" />
     <InternalsVisibleTo Include="$(AssemblyName).Module" />


### PR DESCRIPTION
This removes the check in the regex as different object types have their own limits.

Fixes: https://github.com/jborean93/PSOpenAD/issues/90