### PR TITLE
Improve -Identity lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.1 - TBD
 
 + Remove length check for `sAMAccountName` when used in the `-Identity` parameter
++ Fix the search base and scope when using `Get-OpenAD*` with the `-Identity` parameter, it should now be possible to find objects not in the `defaultNamingContext`
 
 ## v0.6.0 - 2025-03-12
 

--- a/src/PSOpenAD/ADIdentity.cs
+++ b/src/PSOpenAD/ADIdentity.cs
@@ -21,7 +21,7 @@ public class ADObjectIdentity
         }
         else
         {
-            LDAPFilter = DistinguishedNameFilter(value);
+            LDAPFilter = new FilterPresent("objectClass");
             DistinguishedName = value;
         }
 
@@ -53,11 +53,6 @@ public class ADObjectIdentity
     {
         return new FilterEquality("objectGUID", objectGuid.ToByteArray());
     }
-
-    internal static LDAPFilter DistinguishedNameFilter(string dn)
-    {
-        return new FilterEquality("distinguishedName", LDAPFilter.EncodeSimpleFilterValue(dn));
-    }
 }
 
 public class ADPrincipalIdentity : ADObjectIdentity
@@ -76,7 +71,7 @@ public class ADPrincipalIdentity : ADObjectIdentity
             LDAPFilter = filter;
         else
         {
-            LDAPFilter = DistinguishedNameFilter(value);
+            LDAPFilter = new FilterPresent("objectClass");
             DistinguishedName = value;
         }
     }


### PR DESCRIPTION
Improves the logic for finding an AD object that is not in the default naming context. This matches the behaviour of the builtin AD cmdlets.