### PR TITLE
Fix Get-OpenADGroupMember with empty group

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,5 @@
     //"powershell.debugging.createTemporaryIntegratedConsole": true,
     // We use Pester v5 so we don't need the legacy code lens
     "powershell.pester.useLegacyCodeLens": false,
-    "dotnet.defaultSolution": "PSOpenAD.sln",
+    "dotnet.defaultSolution": "PSOpenAD.slnx",
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog for PSOpenAD
 
-## v0.6.1 - TBD
+## v0.7.0 - TBD
 
++ Added `Add-OpenADGroupMember` and `Remove-OpenADGroupMember` to manage AD group members
++ Fixed `Get-OpenADGroupMember` raising an error when the group exists but contains no members, instead it just outputs nothing
 + Remove length check for `sAMAccountName` when used in the `-Identity` parameter
 + Fix the search base and scope when using `Get-OpenAD*` with the `-Identity` parameter, it should now be possible to find objects not in the `defaultNamingContext`
 

--- a/module/PSOpenAD.psd1
+++ b/module/PSOpenAD.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'PSOpenAD.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '0.6.1'
+    ModuleVersion          = '0.7.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSOpenAD.Module/Commands/GetOpenAD.cs
+++ b/src/PSOpenAD.Module/Commands/GetOpenAD.cs
@@ -21,6 +21,8 @@ public abstract class GetOpenADOperation<T> : OpenADSessionCmdletBase
 
     internal abstract LDAPFilter FilteredClass { get; }
 
+    internal virtual bool CheckNoSuchObject => true;
+
     internal abstract OpenADObject CreateADObject(Dictionary<string, (PSObject[], bool)> attributes);
 
     #region Connection Parameters
@@ -250,7 +252,7 @@ public abstract class GetOpenADOperation<T> : OpenADSessionCmdletBase
             WriteObject(adObj);
         }
 
-        if (noSuchObject && ParameterSetName.EndsWith("Identity"))
+        if (CheckNoSuchObject && noSuchObject && ParameterSetName.EndsWith("Identity"))
         {
             string msg = $"Cannot find an object with identity filter '{finalFilter}' under search base '{searchBase}' with scope {searchScope}";
             ErrorRecord rec = new(new ItemNotFoundException(msg), "IdentityNotFound",

--- a/src/PSOpenAD.Module/Commands/GetOpenADGroupMember.cs
+++ b/src/PSOpenAD.Module/Commands/GetOpenADGroupMember.cs
@@ -23,6 +23,8 @@ public class GetOpenADGroupMember : GetOpenADOperation<ADPrincipalIdentity>
     internal override LDAPFilter FilteredClass
         => new FilterEquality("objectCategory", LDAP.LDAPFilter.EncodeSimpleFilterValue("group"));
 
+    internal override bool CheckNoSuchObject => false;
+
     internal override OpenADObject CreateADObject(Dictionary<string, (PSObject[], bool)> attributes)
         => new OpenADPrincipal(attributes);
 
@@ -35,10 +37,14 @@ public class GetOpenADGroupMember : GetOpenADOperation<ADPrincipalIdentity>
         IList<LDAPControl>? serverControls,
         Func<LDAPResult, bool> errorHandler)
     {
+        bool noSuchObject = true;
+
         foreach (SearchResultEntry group in Operations.LdapSearchRequest(session.Connection, searchBase,
             searchScope, 1, session.OperationTimeout, filter, new[] { "primaryGroupToken" }, serverControls,
             CancelToken, this, false, errorHandler))
         {
+            noSuchObject = false;
+
             // use memberOf rather than member to make recursive search easier & avoid paging
             LDAPFilter memberOfFilter;
             if (Recursive)
@@ -90,6 +96,14 @@ public class GetOpenADGroupMember : GetOpenADOperation<ADPrincipalIdentity>
             {
                 _currentGroupDN = "";
             }
+        }
+
+        if (noSuchObject && ParameterSetName.EndsWith("Identity"))
+        {
+            string msg = $"Cannot find an object with identity filter '{filter}' under search base '{searchBase}' with scope {searchScope}";
+            ErrorRecord rec = new(new ItemNotFoundException(msg), "IdentityNotFound",
+                ErrorCategory.ObjectNotFound, searchBase);
+            WriteError(rec);
         }
     }
 

--- a/tests/Get-OpenADGroupMember.Tests.ps1
+++ b/tests/Get-OpenADGroupMember.Tests.ps1
@@ -133,6 +133,17 @@ Describe "Get-OpenADGroupMember cmdlet" -Skip:(-not $PSOpenADSettings.Server) {
             } | Should -Throw -ExpectedMessage "One or more properties for person are not valid: 'invalid1', 'invalid2'"
         }
 
+        It "Does not error on empty group" {
+            $actual = Get-OpenADGroupMember -Identity 'TestGroupEmpty' -Session $session
+            $actual | Should -BeNullOrEmpty
+        }
+
+        It "Errors when group is not found" {
+            {
+                Get-OpenADGroupMember -Identity 'ThisGroupDoesNotExist' -Session $session -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage "Cannot find an object with identity filter '(&(objectCategory=group)(sAMAccountName=ThisGroupDoesNotExist))' under search base '*' with scope Subtree"
+        }
+
         It "Completes the properties selected" {
             $actual = Complete 'Get-OpenADGroupMember -Identity "Administrators" -Session $session -Property '
             $actual.Count | Should -BeGreaterThan 0

--- a/tools/setup-samba.sh
+++ b/tools/setup-samba.sh
@@ -273,6 +273,9 @@ samba-tool group add \
 samba-tool group add \
     TestGroupSub
 
+samba-tool group add \
+    TestGroupEmpty
+
 samba-tool user create \
     TestGroupMember Password01!
 


### PR DESCRIPTION
This change makes sure that `Get-OpenADGroupMember` does not write an error if the group has no members. Instead it will output no items as there are no members. The cmdlet will still error if the `-Identity` points to a group that does not exist.