### PR TITLE
Fix up LDAP parser errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 + Added `Add-OpenADGroupMember` and `Remove-OpenADGroupMember` to manage AD group members
 + Fixed `Get-OpenADGroupMember` raising an error when the group exists but contains no members, instead it just outputs nothing
-+ Fix parsing errors for `-LDAPFilter` to properly include the parsing error location due to changes in the PowerShell error formatter
-  + PowerShell 7.7+ is required to see the offsets in the line but previous versions will still see slightly less verbose error message
++ Fixed parsing errors for `-LDAPFilter` to properly include the parsing error location due to changes in the PowerShell error formatter
+  + PowerShell 7.7+ is required to see the column offsets in the line, but previous versions will still see a slightly less verbose error message
 + Remove length check for `sAMAccountName` when used in the `-Identity` parameter
 + Fix the search base and scope when using `Get-OpenAD*` with the `-Identity` parameter, it should now be possible to find objects not in the `defaultNamingContext`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 + Added `Add-OpenADGroupMember` and `Remove-OpenADGroupMember` to manage AD group members
 + Fixed `Get-OpenADGroupMember` raising an error when the group exists but contains no members, instead it just outputs nothing
++ Fix parsing errors for `-LDAPFilter` to properly include the parsing error location due to changes in the PowerShell error formatter
+  + PowerShell 7.7+ is required to see the offsets in the line but previous versions will still see slightly less verbose error message
 + Remove length check for `sAMAccountName` when used in the `-Identity` parameter
 + Fix the search base and scope when using `Get-OpenAD*` with the `-Identity` parameter, it should now be possible to find objects not in the `defaultNamingContext`
 

--- a/src/PSOpenAD.Module/Commands/GetOpenAD.cs
+++ b/src/PSOpenAD.Module/Commands/GetOpenAD.cs
@@ -1,5 +1,6 @@
 using PSOpenAD.LDAP;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
@@ -131,23 +132,21 @@ public abstract class GetOpenADOperation<T> : OpenADSessionCmdletBase
                     e,
                     "InvalidLDAPFilterException",
                     ErrorCategory.ParserError,
-                    LDAPFilter);
-
-                rec.ErrorDetails = new($"Failed to parse LDAP Filter: {e.Message}");
-
-                // By setting the InvocationInfo we get a nice error description in PowerShell with positional
-                // details. Unfortunately this is not publicly settable so we have to use reflection.
-                if (!string.IsNullOrWhiteSpace(e.Filter))
+                    new Hashtable()
+                    {
+                        // PowerShell uses these properties to give a nicer
+                        // error message with the position of the error in the
+                        // message.
+                        { "Line", 1 },
+                        { "LineText", LDAPFilter.ToString() },
+                        // // Support for columns were added in PS 7.7, it is
+                        // // ignored on older versions.
+                        { "StartColumn", e.StartPosition + 1 },
+                        { "EndColumn", e.EndPosition + 1 }
+                    })
                 {
-                    ScriptPosition start = new("", 1, e.StartPosition + 1, e.Filter);
-                    ScriptPosition end = new("", 1, e.EndPosition + 1, e.Filter);
-                    InvocationInfo info = InvocationInfo.Create(
-                        MyInvocation.MyCommand,
-                        new ScriptExtent(start, end));
-                    rec.GetType().GetField(
-                        "_invocationInfo",
-                        BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(rec, info);
-                }
+                    ErrorDetails = new($"Failed to parse LDAP Filter: {e.Message}")
+                };
 
                 ThrowTerminatingError(rec);
                 return; // Satisfies nullability checks

--- a/src/PSOpenAD.Module/Commands/GetOpenAD.cs
+++ b/src/PSOpenAD.Module/Commands/GetOpenAD.cs
@@ -138,9 +138,9 @@ public abstract class GetOpenADOperation<T> : OpenADSessionCmdletBase
                         // error message with the position of the error in the
                         // message.
                         { "Line", 1 },
-                        { "LineText", LDAPFilter.ToString() },
-                        // // Support for columns were added in PS 7.7, it is
-                        // // ignored on older versions.
+                        { "LineText", e.Filter },
+                        // Support for columns were added in PS 7.7, it is
+                        // ignored on older versions.
                         { "StartColumn", e.StartPosition + 1 },
                         { "EndColumn", e.EndPosition + 1 }
                     })

--- a/tests/Get-OpenADObject.Tests.ps1
+++ b/tests/Get-OpenADObject.Tests.ps1
@@ -69,6 +69,21 @@ Describe "Get-OpenADObject cmdlets" -Skip:(-not $PSOpenADSettings.Server) {
             $actual = Get-OpenADObject -Session $session -Identity "CN=Directory Service,CN=Windows NT,CN=Services,$($dse.ConfigurationNamingContext)" -Properties sPNMappings
             $actual.sPNMappings | Should -Not -BeNullOrEmpty
         }
+
+        It "Emits ParserError for invalid LDAP filter" {
+            $expected = "Extra data found at filter end"
+            $err = {
+                Get-OpenADObject -Session $session -LDAPFilter '(cn=test);2=1'
+            } | Should -Throw -ExpectedMessage $expected -PassThru
+
+            $err.FullyQualifiedErrorId | Should -Be 'InvalidLDAPFilterException,PSOpenAD.Module.Commands.GetOpenADObject'
+            $err.CategoryInfo.Category | Should -Be 'ParserError'
+            $err.TargetObject | Should -BeOfType ([Hashtable])
+            $err.TargetObject.Line | Should -Be 1
+            $err.TargetObject.LineText | Should -Be '(cn=test);2=1'
+            $err.TargetObject.StartColumn | Should -Be 10
+            $err.TargetObject.EndColumn | Should -Be 14
+        }
     }
 
     Context "Get-OpenADComputer" {


### PR DESCRIPTION
A change in PowerShell 7.4 broke the logic the parser error was using to display the filter offset being displayed on a parser error. This uses a newer API to bring back a better error message for existing PowerShell versions as well as support for an even better API used in PowerSHell 7.7+.