### PR TITLE
Don't send the paged result control on Base scope searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   + PowerShell 7.7+ is required to see the column offsets in the line, but previous versions will still see a slightly less verbose error message
 + Remove length check for `sAMAccountName` when used in the `-Identity` parameter
 + Fix the search base and scope when using `Get-OpenAD*` with the `-Identity` parameter, it should now be possible to find objects not in the `defaultNamingContext`
++ Fixed `Get-OpenADRootDSE` and session setup failing with `-AuthType Anonymous` against Active Directory - the paged result control is no longer sent on `Base` scope searches, where it cannot apply and which AD rejects on an anonymous connection
 
 ## v0.6.0 - 2025-03-12
 

--- a/src/PSOpenAD/Operations.cs
+++ b/src/PSOpenAD/Operations.cs
@@ -194,12 +194,25 @@ internal static class Operations
         byte[]? paginationCookie = null;
         bool request = true;
 
+        // A Base scope search returns at most one entry, so the paged result
+        // control can never do anything useful there. It is also actively
+        // harmful: Active Directory rejects the control on an anonymous
+        // connection with "In order to perform this operation a successful bind
+        // must be completed on the connection" (operationsError), even though
+        // the same search without controls is allowed. That made every
+        // anonymous RootDSE read fail, i.e. -AuthType Anonymous was unusable
+        // against a default AD DC.
+        bool usePagination = scope != SearchScope.Base;
+
         while (true)
         {
             if (request)
             {
                 List<LDAPControl> copiedControls = controls?.ToList() ?? new();
-                copiedControls.Add(new PagedResultControl(false, paginationLimit, paginationCookie));
+                if (usePagination)
+                {
+                    copiedControls.Add(new PagedResultControl(false, paginationLimit, paginationCookie));
+                }
                 searchId = connection.Session.Search(searchBase, scope, DereferencingPolicy.Never, sizeLimit,
                     timeLimit / 1000, false, filter, attributes, copiedControls);
 


### PR DESCRIPTION
For https://github.com/jborean93/PSOpenAD/issues/103

`Get-OpenADRootDSE -AuthType Anonymous` fails against a default Active Directory DC with "Cannot find AD RootDSE object", while the equivalent anonymous `ldapsearch -x` succeeds.

`LdapSearchRequest` adds `PagedResultControl` to every search. On a `Base` scope search the control can never do anything - the search returns at most one entry - and AD rejects it on an anonymous connection with:

    000004DC: LdapErr: DSID-0C090C06, comment: In order to perform this
    operation a successful bind must be completed on the connection.

The anonymous simple bind itself succeeds; it is only the control-bearing search that is refused. This can be reproduced without PSOpenAD, the only difference between these two being the control:

    ldapsearch -x -H ldap://dc -s base -b "" defaultNamingContext
    ldapsearch -x -H ldap://dc -s base -b "" -E pr=1000/noprompt defaultNamingContext

`New-OpenADSession -AuthType Anonymous` is affected the same way and ends up with an empty DefaultNamingContext, since session setup performs the same RootDSE lookup.

Skip pagination when the scope cannot produce more than one entry.