### PR TITLE
Look up the default DC on first use, not on module import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.8.0 - TBD
 
++ The default domain controller lookup (`DsGetDcName` on Windows, the krb5 default realm and its `_ldap._tcp.dc._msdcs` SRV records elsewhere) is now done the first time a cmdlet is run without `-Server` or `-Session` rather than when the module is imported, so `Import-Module` no longer waits on DNS when those records are unreachable
+
 ## v0.7.0 - 2026-08-27
 
 + Added `Add-OpenADGroupMember` and `Remove-OpenADGroupMember` to manage AD group members

--- a/docs/en-US/about_OpenADSessions.md
+++ b/docs/en-US/about_OpenADSessions.md
@@ -60,6 +60,10 @@ If any records are returned the default DC is set to the record with the preferr
 
 If any of these steps fail then no default DC is available and PSOpenAD is only able to create a connection when an explicit server or connection uri was provided.
 
+The lookup is done the first time a cmdlet needs the default DC in a PowerShell session, not when the module is imported, so importing PSOpenAD does not wait on DNS.
+The result, or the failure, is kept for the rest of the session.
+Import the module again with `Import-Module PSOpenAD -Force` to retry the lookup after fixing the environment.
+
 # TRACE LOGGING
 It is possible to do trace logging for the raw LDAP messages that are exchanged for debugging purposes.
 To enable trace logging use the `-TracePath` parameter with `New-OpenADSessionOption` when creating a new session.

--- a/src/PSOpenAD.Module/DefaultDcDiscovery.cs
+++ b/src/PSOpenAD.Module/DefaultDcDiscovery.cs
@@ -1,0 +1,170 @@
+using DnsClient;
+using PSOpenAD.Native;
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Management.Automation;
+using System.Runtime.InteropServices;
+
+namespace PSOpenAD.Module;
+
+/// <summary>
+/// Finds the default domain controller used for implicit sessions. On Windows this is DsGetDcName, elsewhere the
+/// krb5 default realm and a DNS SRV lookup for it. Both can block for a long time when the records are not
+/// reachable, so the lookup is done the first time a default DC is needed rather than when the module is imported.
+/// </summary>
+internal static class DefaultDcDiscovery
+{
+    /// <summary>Does the default DC lookup if it has not already been done for this runspace.</summary>
+    /// <param name="state">The runspace state the result is stored in.</param>
+    /// <param name="cmdlet">PSCmdlet to write verbose records to.</param>
+    internal static void Ensure(GlobalState state, PSCmdlet cmdlet)
+    {
+        if (state.DefaultDCLookupDone)
+        {
+            return;
+        }
+
+        cmdlet.WriteVerbose("Looking up the default domain controller");
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                LookupWindows(state);
+            }
+            else
+            {
+                LookupUnix(state);
+            }
+        }
+        finally
+        {
+            state.DefaultDCLookupDone = true;
+        }
+    }
+
+    private static void LookupWindows(GlobalState state)
+    {
+        const GetDcFlags getDcFlags = GetDcFlags.DS_IS_DNS_NAME | GetDcFlags.DS_ONLY_LDAP_NEEDED |
+            GetDcFlags.DS_RETURN_DNS_NAME | GetDcFlags.DS_WRITABLE_REQUIRED;
+        string? dcName = null;
+        try
+        {
+            DCInfo dcInfo = NetApi32.DsGetDcName(null, null, null, getDcFlags, null);
+            dcName = dcInfo.Name?.TrimStart('\\');
+        }
+        catch (Win32Exception e) when (e.NativeErrorCode == 1355) // ERROR_NO_SUCH_DOMAIN
+        {
+            // While it's questionable why you would use this module if it hasn't been joined to a domain it's
+            // still possible to use this for any LDAP server on Windows so just ignore the default DC setup.
+        }
+        catch (Exception e)
+        {
+            state.DefaultDCError = $"Failure calling DsGetDcName to get default DC: {e.Message}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(dcName))
+        {
+            state.DefaultDC = new($"ldap://{dcName}:389/");
+        }
+        else if (string.IsNullOrEmpty(state.DefaultDCError))
+        {
+            state.DefaultDCError = "No configured default DC on host";
+        }
+    }
+
+    private static void LookupUnix(GlobalState state)
+    {
+        if (TryGetDefaultKerberosRealm(out var defaultRealm, out var realmException))
+        {
+            // _ldap._tcp.dc._msdcs.domain.com
+            string baseDomain = $"dc._msdcs.{defaultRealm}";
+            LookupClient dnsLookup = new();
+            try
+            {
+                ServiceHostEntry[] res = dnsLookup.ResolveService(baseDomain, "ldap",
+                    System.Net.Sockets.ProtocolType.Tcp);
+
+                ServiceHostEntry? first = res.OrderBy(r => r.Priority).ThenBy(r => r.Weight).FirstOrDefault();
+                if (first != null)
+                {
+                    state.DefaultDC = new($"ldap://{first.HostName}:{first.Port}/");
+                }
+                else
+                {
+                    state.DefaultDCError = $"No SRV records for _ldap._tcp.{baseDomain} found";
+                }
+            }
+            catch (DnsResponseException e)
+            {
+                state.DefaultDCError = $"DNS Error looking up SRV records for _ldap._tcp.{baseDomain}: {e.Message}";
+            }
+            catch (Exception e)
+            {
+                state.DefaultDCError = $"Unknown error looking up SRV records for _ldap._tcp.{baseDomain}: {e.GetType().Name} - {e.Message}";
+            }
+        }
+        else
+        {
+            state.DefaultDCError = $"Failed to lookup krb5 default realm: {realmException}";
+        }
+    }
+
+    /// <summary>
+    /// Attempt to get the default Kerberos realm from the system for the DC lookup.
+    /// </summary>
+    /// <param name="realm">The realm if the method returns true.</param>
+    /// <param name="errorMessage">The error details if the method returns false.</param>
+    /// <returns>True if the realm was successfully retrieved, otherwise false.</returns>
+    private static bool TryGetDefaultKerberosRealm(
+        [NotNullWhen(true)] out string? realm,
+        [NotNullWhen(false)] out string? errorMessage)
+    {
+        realm = null;
+        errorMessage = null;
+
+        using var ctx = Kerberos.InitContext();
+        if (Kerberos.TryGetDefaultRealm(ctx, out realm, out var defaultRealmException))
+        {
+            return true;
+        }
+
+        if (!Kerberos.TryGetDefaultCCache(ctx, out var ccache, out var defaultCCException))
+        {
+            errorMessage = $"{defaultRealmException.Message}, {defaultCCException.Message}";
+            return false;
+        }
+        using (ccache)
+        {
+            if (!Kerberos.TryGetCCachePrincipal(ctx, ccache, out var principal, out var defaultCCPrincipalException))
+            {
+                errorMessage = $"{defaultRealmException.Message}, {defaultCCPrincipalException.Message}";
+                return false;
+            }
+
+            using (principal)
+            {
+                if (Kerberos.TryUnparseName(ctx, principal, out var principalName, out var defaultUnparseException))
+                {
+                    int realmIdx = principalName.IndexOf('@');
+                    if (realmIdx != -1)
+                    {
+                        realm = principalName[(realmIdx + 1)..];
+                        return true;
+                    }
+                    else
+                    {
+                        errorMessage = $"{defaultRealmException.Message}, failed to find principal realm in name '{principalName}'";
+                        return false;
+                    }
+                }
+                else
+                {
+                    errorMessage = $"{defaultRealmException.Message}, {defaultUnparseException.Message}";
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/PSOpenAD.Module/OnImportAndRemove.cs
+++ b/src/PSOpenAD.Module/OnImportAndRemove.cs
@@ -1,10 +1,6 @@
-using DnsClient;
 using PSOpenAD.Native;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -92,6 +88,12 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
 
         GlobalState state = GlobalState.GetFromTLS();
 
+        // The default DC lookup is done on first use (see DefaultDcDiscovery), re-importing the module lets it run
+        // again.
+        state.DefaultDC = null;
+        state.DefaultDCError = null;
+        state.DefaultDCLookupDone = false;
+
         // While channel binding isn't technically done by both these methods an Active Directory implementation
         // doesn't validate it's presence so from the purpose of a client it does work even if it's enforced on the
         // server end.
@@ -110,33 +112,6 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                 true, true, "");
             state.Providers[AuthenticationMethod.Negotiate] = new(AuthenticationMethod.Negotiate,
                 "GSS-SPNEGO", true, true, "");
-
-            const GetDcFlags getDcFlags = GetDcFlags.DS_IS_DNS_NAME | GetDcFlags.DS_ONLY_LDAP_NEEDED |
-                GetDcFlags.DS_RETURN_DNS_NAME | GetDcFlags.DS_WRITABLE_REQUIRED;
-            string? dcName = null;
-            try
-            {
-                DCInfo dcInfo = NetApi32.DsGetDcName(null, null, null, getDcFlags, null);
-                dcName = dcInfo.Name?.TrimStart('\\');
-            }
-            catch (Win32Exception e) when (e.NativeErrorCode == 1355) // ERROR_NO_SUCH_DOMAIN
-            {
-                // While it's questionable why you would use this module if it hasn't been joined to a domain it's
-                // still possible to use this for any LDAP server on Windows so just ignore the default DC setup.
-            }
-            catch (Exception e)
-            {
-                state.DefaultDCError = $"Failure calling DsGetDcName to get default DC: {e.Message}";
-            }
-
-            if (!string.IsNullOrWhiteSpace(dcName))
-            {
-                state.DefaultDC = new($"ldap://{dcName}:389/");
-            }
-            else if (string.IsNullOrEmpty(state.DefaultDCError))
-            {
-                state.DefaultDCError = "No configured default DC on host";
-            }
         }
         else
         {
@@ -160,6 +135,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                     "GSS-SPNEGO", false, false, "GSSAPI library not found");
 
                 state.DefaultDCError = "Failed to find GSSAPI library";
+                state.DefaultDCLookupDone = true;
             }
             else
             {
@@ -183,47 +159,12 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                     state.GssapiProvider = GssapiProvider.MIT;
                 }
 
-                // If the krb5 API is available, attempt to get the default realm used when creating an implicit
-                // session.
-                if (krb5Lib != null)
-                {
-                    if (TryGetDefaultKerberosRealm(out var defaultRealm, out var realmException))
-                    {
-                        // _ldap._tcp.dc._msdcs.domain.com
-                        string baseDomain = $"dc._msdcs.{defaultRealm}";
-                        LookupClient dnsLookup = new();
-                        try
-                        {
-                            ServiceHostEntry[] res = dnsLookup.ResolveService(baseDomain, "ldap",
-                                System.Net.Sockets.ProtocolType.Tcp);
-
-                            ServiceHostEntry? first = res.OrderBy(r => r.Priority).ThenBy(r => r.Weight).FirstOrDefault();
-                            if (first != null)
-                            {
-                                state.DefaultDC = new($"ldap://{first.HostName}:{first.Port}/");
-                            }
-                            else
-                            {
-                                state.DefaultDCError = $"No SRV records for _ldap._tcp.{baseDomain} found";
-                            }
-                        }
-                        catch (DnsResponseException e)
-                        {
-                            state.DefaultDCError = $"DNS Error looking up SRV records for _ldap._tcp.{baseDomain}: {e.Message}";
-                        }
-                        catch (Exception e)
-                        {
-                            state.DefaultDCError = $"Unknown error looking up SRV records for _ldap._tcp.{baseDomain}: {e.GetType().Name} - {e.Message}";
-                        }
-                    }
-                    else
-                    {
-                        state.DefaultDCError = $"Failed to lookup krb5 default realm: {realmException}";
-                    }
-                }
-                else
+                // The krb5 API is needed to find the default realm for the default DC lookup, without it there
+                // is nothing to look up later.
+                if (krb5Lib == null)
                 {
                     state.DefaultDCError = "Failed to find Kerberos library";
+                    state.DefaultDCLookupDone = true;
                 }
             }
         }
@@ -237,62 +178,5 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
 
         state.Sessions = new();
         Resolver?.Dispose();
-    }
-
-    /// <summary>
-    /// Attempt to get the default Kerberos realm from the system for the DC lookup.
-    /// </summary>
-    /// <param name="realm">The realm if the method returns true.</param>
-    /// <param name="errorMessage">The error details if the method returns false.</param>
-    /// <returns>True if the realm was successfully retrieved, otherwise false.</returns>
-    private static bool TryGetDefaultKerberosRealm(
-        [NotNullWhen(true)] out string? realm,
-        [NotNullWhen(false)] out string? errorMessage)
-    {
-        realm = null;
-        errorMessage = null;
-
-        using var ctx = Kerberos.InitContext();
-        if (Kerberos.TryGetDefaultRealm(ctx, out realm, out var defaultRealmException))
-        {
-            return true;
-        }
-
-        if (!Kerberos.TryGetDefaultCCache(ctx, out var ccache, out var defaultCCException))
-        {
-            errorMessage = $"{defaultRealmException.Message}, {defaultCCException.Message}";
-            return false;
-        }
-        using (ccache)
-        {
-            if (!Kerberos.TryGetCCachePrincipal(ctx, ccache, out var principal, out var defaultCCPrincipalException))
-            {
-                errorMessage = $"{defaultRealmException.Message}, {defaultCCPrincipalException.Message}";
-                return false;
-            }
-
-            using (principal)
-            {
-                if (Kerberos.TryUnparseName(ctx, principal, out var principalName, out var defaultUnparseException))
-                {
-                    int realmIdx = principalName.IndexOf('@');
-                    if (realmIdx != -1)
-                    {
-                        realm = principalName[(realmIdx + 1)..];
-                        return true;
-                    }
-                    else
-                    {
-                        errorMessage = $"{defaultRealmException.Message}, failed to find principal realm in name '{principalName}'";
-                        return false;
-                    }
-                }
-                else
-                {
-                    errorMessage = $"{defaultRealmException.Message}, {defaultUnparseException.Message}";
-                    return false;
-                }
-            }
-        }
     }
 }

--- a/src/PSOpenAD.Module/OpenADSessionFactory.cs
+++ b/src/PSOpenAD.Module/OpenADSessionFactory.cs
@@ -27,6 +27,8 @@ internal sealed class OpenADSessionFactory
 
         if (string.IsNullOrEmpty(server))
         {
+            DefaultDcDiscovery.Ensure(state, cmdlet);
+
             if (state.DefaultDC == null)
             {
                 string msg = "Cannot determine default realm for implicit domain controller.";

--- a/src/PSOpenAD/GlobalState.cs
+++ b/src/PSOpenAD/GlobalState.cs
@@ -58,5 +58,8 @@ internal class GlobalState
     /// <summary>If the default DC couldn't be detected this stores the details.</summary>
     public string? DefaultDCError;
 
+    /// <summary>Set once the default DC lookup has been done for this runspace, whether it succeeded or not.</summary>
+    public bool DefaultDCLookupDone;
+
     public static GlobalState GetFromTLS() => _state.GetFromTLS();
 }


### PR DESCRIPTION
`OnImport()` looks up the default domain controller so that cmdlets can be run without `-Server`. On Windows that is `DsGetDcName`, elsewhere it reads the krb5 default realm and resolves the `_ldap._tcp.dc._msdcs.<realm>` SRV records.

Both can block for a long time when those records are not reachable, and the wait is paid by every `Import-Module PSOpenAD`, including the many that go on to pass an explicit `-Server` or `-Session` and never need a default DC at all. A client that is off the corporate network, or on a VPN that does not carry the internal DNS zone, resolves the realm from krb5.conf and then waits for the SRV query to time out. Measured on macOS with the realm configured but the DNS servers unreachable, import took 15.2 seconds; the same import with this change takes 0.09 seconds.

Move the lookup into DefaultDcDiscovery and run it the first time a cmdlet actually needs a default DC. The result, success or failure, is kept in the runspace state so it is looked up at most once, and the existing error text is unchanged, so a caller with no default DC sees the same message it does today, just at first use rather than at import. Importing the module again resets the state and retries the lookup.

The two cases that are already known at import time, no GSSAPI library and no Kerberos library, still set their error there and mark the lookup done.

This changes when the lookup runs, not how it finds its answer, so it should sit alongside whatever you decide for module scoped settings such as the DNS configuration.
